### PR TITLE
arkham: handle the `comesfrom` statement tag

### DIFF
--- a/src/arkham/analyser.nim
+++ b/src/arkham/analyser.nim
@@ -523,6 +523,19 @@ proc analyse(c: var Context; n: var Cursor) =
         if frame.sawCall: c.loopStack[^1].sawCall = true
         for pnm in frame.usedParams: c.loopStack[^1].usedParams.incl pnm
     else:
+      when declared(ComesfromS):
+        if n.stmtKind == ComesfromS:
+          # `(comesfrom SYM S*)`: debug-info marker, walks like `stmts` but
+          # opens no scope frame. The leading child is the origin SYMBOL, not a
+          # statement, so `analyseChildren` would analyse it as a symbol *use*
+          # and record a read of the expanded routine at this position.
+          #
+          # Guarded so arkham still compiles against a nimony that predates the
+          # tag (nim-lang/nimony#2240); drop the `when` once that has merged.
+          n.into:
+            skip n                        # the origin symbol
+            while n.hasMore: analyse(c, n)
+          return
       analyseChildren(c, n)             # if/case/ret/... : recurse
   else:
     inc n

--- a/src/arkham/codegen_a64.nim
+++ b/src/arkham/codegen_a64.nim
@@ -4702,7 +4702,22 @@ proc genStmt2(g: var CodeGen; c: Cursor) =
           g.ovfReg2 = rB
           g.ovfBridges = @[rA, rB]
       while cc.hasMore: skip cc
-  else: raiseAssert "arkham a64n: genStmt2 " & $c.stmtKind
+  else:
+    when declared(ComesfromS):
+      if c.stmtKind == ComesfromS:
+        # `(comesfrom SYM S*)` — statements produced by expanding SYM (a
+        # template today). Debug-info only: no scope and no code of its own, so
+        # it behaves as `stmts` once the leading origin SYMBOL is stepped over.
+        # That first child is an operand, not a statement.
+        #
+        # Guarded so arkham still compiles against a nimony that predates the
+        # tag (nim-lang/nimony#2240); drop the `when` once that has merged.
+        var cc = c
+        cc.into:
+          skip cc                               # the origin symbol
+          while cc.hasMore: (g.genStmt2(cc); skip cc)
+        return
+    raiseAssert "arkham a64n: genStmt2 " & $c.stmtKind
 
 # ── proc emission / driver (pure-emit path) ──────────────────────────────────
 

--- a/src/arkham/codegen_x64.nim
+++ b/src/arkham/codegen_x64.nim
@@ -4590,7 +4590,25 @@ proc genStmt2(g: var CodeGen; c: Cursor) =
         g.genStore2(opCur, memLoc(lhsCur, ScalarSlot))
       g.noFoldPos = -1
       while cc.hasMore: skip cc
-  else: raiseAssert "arkham x64n: genStmt2 " & $c.stmtKind
+  else:
+    when declared(ComesfromS):
+      if c.stmtKind == ComesfromS:
+        # `(comesfrom SYM S*)` — statements produced by expanding SYM (a
+        # template today). Debug-info only: no scope and no code of its own, so
+        # it behaves as `stmts` once the leading origin SYMBOL is stepped over.
+        # That first child is an operand, not a statement.
+        #
+        # Guarded so arkham still compiles against a nimony that predates the
+        # tag (nim-lang/nimony#2240); drop the `when` once that has merged.
+        var cc = c
+        cc.into:
+          skip cc                               # the origin symbol
+          while cc.hasMore:
+            var nx = cc; skip nx
+            g.tailStmt = myTail and not nx.hasMore
+            g.genStmt2(cc); skip cc
+        return
+    raiseAssert "arkham x64n: genStmt2 " & $c.stmtKind
 
 # ── fused value core: unconverted-proc stubs (die as each case lands) ────────
 proc emitBin2(g: var CodeGen; c: Cursor; dest: var Location) =
@@ -6838,6 +6856,19 @@ proc asmStmt(g: var CodeGen; c: Cursor) =
       g.retLabelUsed2 = true
       g.emJmp(g.retLabel2)
   else:
+    when declared(ComesfromS):
+      if c.stmtKind == ComesfromS:
+        # See `genStmt2`: transparent debug-info marker, first child is an
+        # operand. Guarded so arkham still compiles against a nimony that
+        # predates the tag (nim-lang/nimony#2240).
+        var cc = c
+        cc.into:
+          skip cc                               # the origin symbol
+          while cc.hasMore:
+            var nx = cc; skip nx
+            g.tailStmt = myTail and not nx.hasMore
+            g.asmStmt(cc); skip cc
+        return
     lengError c, "`" & $c.stmtKind & "` is not allowed in an `.assembler` proc", g.asmInfo
 
 proc genAsmProc(g: var CodeGen; info: ProcInfo) =

--- a/src/arkham/register_allocator.nim
+++ b/src/arkham/register_allocator.nim
@@ -527,6 +527,20 @@ proc walk(b: var Builder; n: var Cursor) =
     n.into:
       while n.hasMore: walk(b, n)
   else:
+    when declared(ComesfromS):
+      if n.stmtKind == ComesfromS:
+        # `(comesfrom SYM S*)`: debug-info marker, walks like `stmts`. The
+        # leading child is the origin SYMBOL, not a statement, so the generic
+        # recursion below would count it as a use of the expanded routine here.
+        #
+        # Guarded so arkham still compiles against a nimony that predates the
+        # tag (nim-lang/nimony#2240); drop the `when` once that has merged.
+        n.into:
+          skip n                              # the origin symbol
+          while n.hasMore:
+            walk(b, n)
+            flushFree(b, b.posOf(n))
+        return
     if n.kind == TagLit:
       n.into:
         while n.hasMore: walk(b, n)          # recurse (var decls may nest)


### PR DESCRIPTION
nimony is gaining `(comesfrom SYM S*)` in nim-lang/nimony#2240 - a transparent wrapper marking statements produced by expanding `SYM` (a template today), so the debug backend can emit them as a DWARF inlined frame. It opens no scope and carries no semantics of its own.

Without this, every native test aborts:

```
arkham x64n: genStmt2 comesfrom [AssertionDefect]
0 / 67 native tests successful
```

Needs to land with (or before) that PR, since the tag reaches arkham as soon as it does.

### The one thing to know

The wrapper's first child is the origin **symbol**, not a statement. Four passes walk statement children generically, and each has to step over it:

- **`codegen_x64` `genStmt2` / `asmStmt`, `codegen_a64` `genStmt2`** - emit the body like `stmts`. Deliberately no `enterScope`, unlike `ScopeS`: the locals an expansion declares belong to the enclosing scope.
- **`analyser`** - its generic `analyseChildren` fallback would analyse the leading symbol as a symbol *use*, recording a read of the expanded routine at this position.
- **`register_allocator`** - same, and it would carry that phantom read into the live ranges.

The two analysis passes are the ones worth a second look. They accept the tag through a permissive `else:` without complaint, so a miss there is quiet - it shows up much later as a wrong allocation rather than an assertion. The same shape caused four separate regressions on the nimony side, each found by breakage in a different suite.

`(pragmax pragmas body)` already has this shape, which is why several passes here special-case it too.

### Testing

arkham builds against the nimony branch that introduces the tag, and no `genStmt2 comesfrom` assertion remains. I could not run the native suite to completion - it targets Linux ELF and I am on Windows, where it fails earlier on `ExitProcess`. CI on the nimony PR is the real check.