### PR TITLE
win_x64: fix three bugs blocking a native Windows bootstrap

### DIFF
--- a/src/arkham/programs.nim
+++ b/src/arkham/programs.nim
@@ -1298,7 +1298,70 @@ proc aggrWordCount*(p: var Program; typeSym: SymId): int =
   assert sz <= 16, "arkham v1: >16-byte aggregate ABI (by-ref / x8) not yet supported"
   (sz + 7) div 8
 
+proc layoutObjBody(p: var Program; bodyc: Cursor; base: int;
+                   res: var seq[FieldInfo]) =
+  ## Append `bodyc`'s fields to `res`, each at `base` plus its offset within the
+  ## body. This walk must stay in lockstep with `objSizeAlign`'s — the two answer
+  ## "where is field f" and "how big is the object", and a disagreement puts a
+  ## field's address outside its own object.
+  assert bodyc.kind == TagLit and bodyc.typeKind == ObjectT,
+    "arkham: object layout requires an object body, got " &
+    toString(bodyc, includeLineInfo = false)
+  var oc = bodyc
+  var off = base
+  oc.into:
+    if oc.kind == Symbol:                     # inherited base: its fields come
+      layoutObjBody(p, resolveType(p, oc), base, res)   # first, at their base
+      off = base + aggrByteSize(p, oc.symId)  # offsets (base sits at offset 0)
+    skip oc                                   # base / inheritance slot
+    while oc.hasMore:
+      if oc.kind == TagLit and oc.typeKind == UnionT:
+        # An object VARIANT's union part. Its branches OVERLAP, so each is laid
+        # out from the SAME offset — which is exactly how `fieldType` resolves a
+        # name across all of them, and the layout `objSizeAlign` sizes. Without
+        # this case the `(union …)` node fell into the `(fld …)` arm below and
+        # `symName` asserted on its first child, an `(object …)` TagLit: any
+        # variant type reaching the aggregate-ABI path killed arkham outright.
+        let (usz, ual) = unionSizeAlign(p, oc)
+        off = align(off, ual)
+        var u = oc
+        u.into:
+          while u.hasMore:
+            let br = unionBranchBody(u)
+            if br.kind != DotToken:           # `.` ⇒ branch declares no fields
+              layoutObjBody(p, br, off, res)
+            skip u
+        off += usz
+        skip oc
+      else:
+        oc.into:                              # (fld :name pragmas type)
+          let fn = symName(oc); inc oc
+          skip oc                             # field-pragmas
+          let (fsz, fal) = typeSizeAlign(p, oc)
+          skip oc
+          off = align(off, fal)
+          res.add (name: fn, off: off, size: fsz)
+          off += fsz
+
+proc objBodyHasUnion(p: var Program; bodyc: Cursor): bool =
+  ## Does this object body — or anything it inherits — carry a variant /
+  ## `{.union.}` part? No early `return`: an unbalanced `into` body trips
+  ## nifcore's "did not consume all children" assert.
+  var oc = bodyc
+  result = false
+  oc.into:
+    if oc.kind == Symbol and objBodyHasUnion(p, resolveType(p, oc)):
+      result = true
+    skip oc                                   # base / inheritance slot
+    while oc.hasMore:
+      if oc.kind == TagLit and oc.typeKind == UnionT: result = true
+      skip oc
+
 proc aggrLayout*(p: var Program; typeSym: SymId): seq[FieldInfo] =
+  ## Every field of `typeSym`, at its byte offset. A variant type contributes
+  ## each branch's fields at the SAME offset, so the result can hold two entries
+  ## for one offset — `fieldAtOffset` answers with the first, which is why
+  ## `canHomeInRegPair` refuses variants rather than picking between them.
   result = @[]
   var d = lookupType(p, typeSym)
   var body: Cursor
@@ -1313,22 +1376,7 @@ proc aggrLayout*(p: var Program; typeSym: SymId): seq[FieldInfo] =
     return aggrLayout(p, body.symId)
   assert body.kind == TagLit and body.typeKind == ObjectT,
     "arkham: aggregate ABI requires an object type: " & p.pool.syms[typeSym]
-  var oc = body
-  var off = 0
-  oc.into:
-    if oc.kind == Symbol:                     # inherited base: its fields come
-      result = aggrLayout(p, oc.symId)        # first, at their base offsets (the
-      off = aggrByteSize(p, oc.symId)         # base sits at offset 0 in derived)
-    skip oc                                   # base / inheritance slot
-    while oc.hasMore:
-      oc.into:                                # (fld :name pragmas type)
-        let fn = symName(oc); inc oc
-        skip oc                               # field-pragmas
-        let (fsz, fal) = typeSizeAlign(p, oc)
-        skip oc
-        off = align(off, fal)
-        result.add (name: fn, off: off, size: fsz)
-        off += fsz
+  layoutObjBody(p, body, 0, result)
 
 proc canHomeInRegPair*(p: var Program; typeSym: SymId): bool =
   ## True when every field is a full 8-byte integer/pointer word at an 8-byte
@@ -1346,6 +1394,12 @@ proc canHomeInRegPair*(p: var Program; typeSym: SymId): bool =
   if body.kind == Symbol:
     return canHomeInRegPair(p, body.symId)
   if body.kind != TagLit or body.typeKind != ObjectT: return false
+  # A VARIANT never homes in registers. Its branches overlap, so `aggrLayout`
+  # reports several fields at one offset and `fieldAtOffset` would have to pick
+  # one — but the deciding reason is the same one the `AMem` test below states:
+  # a variant's `=destroy` reaches its payload as `(dot dest val)` and hands
+  # that lvalue to the field's own hook, and a register has no address.
+  if objBodyHasUnion(p, body): return false
   let lay = aggrLayout(p, typeSym)
   if lay.len == 0: return false
   for f in lay:

--- a/src/nifasm/decls.nim
+++ b/src/nifasm/decls.nim
@@ -136,6 +136,13 @@ proc takeLocal*(c: var Cursor): Local =
       result.val = c
       result.hasVal = true
       skip c
+    # An AGGREGATE constant initializer carries one trailing `(reloc <off>
+    # <sym>)` per field holding a symbol ADDRESS, which only the final layout can
+    # fill in — `(gvar :name type "bytes" (reloc …)*)`. They are no part of the
+    # three slots captured above, and `generateSymbol` re-walks the node to read
+    # them, but `into` demands the WHOLE body be consumed, so leaving them made
+    # every such gvar an assertion failure rather than a decl this could bound.
+    while c.hasMore: skip c
 
 type
   TypeDecl* = object

--- a/src/nifasm/pe.nim
+++ b/src/nifasm/pe.nim
@@ -246,8 +246,27 @@ proc initOptionalHeader64*(
                               IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE or
                               IMAGE_DLLCHARACTERISTICS_NX_COMPAT or
                               IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE
-  result.SizeOfStackReserve = 0x100000  # 1MB
-  result.SizeOfStackCommit = 0x1000     # 4KB
+  # The stack is committed IN FULL, not grown on demand. Windows commits a
+  # thread stack lazily: only `SizeOfStackCommit` is mapped, with a PAGE_GUARD
+  # page below it, and the region grows one page at a time as that guard page is
+  # touched. A prologue may only rely on that if it walks down its frame a page
+  # at a time (MSVC's `__chkstk`, gcc's `-fstack-clash-protection`) — arkham's
+  # `emitFrameSub` lowers rsp by the whole `(ssize)` in ONE `sub`, so any frame
+  # bigger than a page lands PAST the guard page, on reserved-but-uncommitted
+  # memory, and the first slot write takes an access violation. That is not
+  # hypothetical: nimsem's own frames reach 24KB (six pages), which is what made
+  # a native Windows boot die in stage 2 while linux/amd64 stayed green — Linux
+  # grows the main thread's stack on any fault within the guard gap, so the same
+  # single `sub` needs no probe there.
+  #
+  # Committing the whole reserve removes the guard-page protocol from the
+  # picture entirely. It costs commit charge (pagefile accounting), not resident
+  # memory — untouched pages are never backed. Emitting probes in `emitFrameSub`
+  # would be the narrower fix, but the frame size is not known until nifasm's
+  # `finalize` patches the `(ssize)` imm32, i.e. after the prologue bytes are
+  # already emitted.
+  result.SizeOfStackReserve = 0x800000  # 8MB, matching the usual Linux default
+  result.SizeOfStackCommit = 0x800000   # == reserve: no lazy growth, no probes
   result.SizeOfHeapReserve = 0x100000   # 1MB
   result.SizeOfHeapCommit = 0x1000      # 4KB
   result.NumberOfRvaAndSizes = 16


### PR DESCRIPTION
Stage 2 of a `nimony n` self-host died on Windows while linux/amd64 stayed green, and `hastur native` was 127/131. Three independent causes:

* nifasm/pe.nim -- missing stack probes. Windows commits a thread stack lazily: only SizeOfStackCommit is mapped, with a PAGE_GUARD page below it, and the region grows one page at a time as that guard page is touched. arkham's emitFrameSub lowers rsp by the whole (ssize) in ONE sub, so any frame bigger than a page lands past the guard page on reserved-but- uncommitted memory and the first slot write takes an access violation -- nimsem's own frames reach 24KB, six pages. Linux grows the main thread's stack on any fault within the guard gap, which is exactly why the same single sub needs no probe there. Commit the whole reserve (8MB) so the guard-page protocol is out of the picture. Emitting real probes is the narrower fix, but the frame size is not known until nifasm's finalize patches the (ssize) imm32, i.e. after the prologue bytes are emitted.

* arkham/programs.nim -- aggrLayout walked an object body assuming every child is a (fld :name pragmas type), so a variant's (union ...) member hit symName on an (object ...) TagLit and killed arkham outright. objSizeAlign and fieldType both already carry a UnionT case; give aggrLayout one too, through a shared layoutObjBody that lays every branch out from the same offset (they overlap) and advances past the union by unionSizeAlign, so it stays in lockstep with objSizeAlign. A variant additionally never homes in a register pair: its =destroy reaches the payload as (dot dest val) and hands that lvalue to the field's own hook, and a register has no address.

* nifasm/decls.nim -- takeLocal captured only name/type/value, but an aggregate constant initializer carries one trailing (reloc <off> <sym>) per field holding a symbol address, and `into` demands the whole body be consumed. generateSymbol already re-walks the node to read them, so drain the rest rather than assert on it.

`hastur native` is now 131/131 on windows/amd64, and HASTUR_NATIVE_BOOT=1 `hastur boot` reaches a byte-identical fixed point (stage1 == stage2 == stage3) in ~400s, against ~600s for the same three stages through the C backend.