### PR TITLE
peephole: answer its liveness question per PROC, not per buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,12 +174,130 @@ jobs:
       #     path: '${{ github.workspace }}/nim-${{ matrix.target.nim_branch }}-${{ matrix.target.cpu }}'
       #     key: 'nim-${{ matrix.target.cpu }}-${{ matrix.target.nim_branch }}'
 
+      # `setup-nim` resolves exactly one tag — the rolling `latest-<branch>` alias
+      # in nim-lang/nightlies — and fails outright when it is absent. On
+      # 2026-08-27 it was absent for `devel`: that day's nightlies run BUILT devel
+      # fine (its dated release carries all nine assets), but the "Push
+      # latest-devel tag" job failed, and that job deletes the alias before it
+      # recreates it:
+      #
+      #     gh release delete -y "$tag" || :
+      #     git push --delete origin "$tag" || :
+      #     gh release create ... "$tag" ...
+      #
+      # so a failure after the deletes leaves no alias at all, and every consumer
+      # stops at "Could not find any release named 'latest-devel'". The dated
+      # releases are what the alias points AT, so the newest one for the branch is
+      # the same compiler reached by a different name.
+      #
+      # This step only decides WHICH of the two following steps runs. When the
+      # alias is there — the normal case — nothing changes: the action installs it
+      # exactly as before.
+      - name: Resolve the Nim nightly
+        id: nim
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          branch='${{ matrix.target.nim_branch }}'
+          # Byte-for-byte the probe `setup-nim`'s own `setup.sh` makes, so this
+          # can never disagree with what the action would then do.
+          if curl -fsI "https://github.com/nim-lang/nightlies/releases/latest-$branch" >/dev/null 2>&1; then
+            echo "alias=true" >> "$GITHUB_OUTPUT"
+            echo "latest-$branch is present; installing it with setup-nim."
+            exit 0
+          fi
+          echo "alias=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::latest-$branch is missing from nim-lang/nightlies (upstream alias job); falling back to the newest dated nightly"
+
+          # The archive names `setup-nim` derives, and the same mapping: a dated
+          # release spells its assets `nim-<version>-<os>_<arch>.<ext>` while the
+          # alias renames them to `<os>_<arch>.<ext>`, so match on the suffix and
+          # let the version float.
+          case '${{ runner.os }}' in
+            Linux)   os=linux ;;
+            macOS)   os=macosx ;;
+            Windows) os=windows ;;
+            *) echo "::error::setup: unknown runner OS '${{ runner.os }}'"; exit 1 ;;
+          esac
+          case '${{ matrix.target.cpu }}' in
+            amd64) arch=x64 ;;
+            i386)  arch=x32 ;;
+            arm64) arch=arm64 ;;
+            *) echo "::error::setup: unknown cpu '${{ matrix.target.cpu }}'"; exit 1 ;;
+          esac
+          # `if`, not `[ … ] && …`: the runner's shell is `bash -e`, and a
+          # trailing AND-list whose test is false is a failed command — the step
+          # would have exited 1 on every host that is not Windows.
+          if [ "$os" = windows ]; then ext=.zip; else ext=.tar.xz; fi
+          suffix="-${os}_${arch}${ext}"
+
+          # Newest first is the API's own order, so `first` after the date-prefix
+          # filter is the newest dated build of this branch. The filter anchors on
+          # the date so it cannot match `latest-version-2-4` and friends.
+          # Authenticated when there is a token (there always is in Actions, and
+          # the unauthenticated API rate limit is per runner IP — i.e. shared).
+          auth=()
+          if [ -n "${GH_TOKEN:-}" ]; then auth=(-H "Authorization: Bearer $GH_TOKEN"); fi
+          url=$(curl -fsSL "${auth[@]}" \
+                  "https://api.github.com/repos/nim-lang/nightlies/releases?per_page=100" |
+                jq -r --arg br "$branch" --arg sfx "$suffix" '
+                  [ .[] | select(.tag_name | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}-" + $br + "-")) ]
+                  | first
+                  | .assets[] | select(.name | endswith($sfx)) | .browser_download_url')
+          if [ -z "$url" ] || [ "$url" = null ]; then
+            echo "::error::setup: no dated nightly for branch '$branch' carries a '*$suffix' asset"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Falling back to $url"
+
       - name: Setup Nim
+        if: steps.nim.outputs.alias == 'true'
         uses: alaviss/setup-nim@0.1.1
         with:
           path: 'nim'
           version: ${{ matrix.target.nim_branch }}
           architecture: ${{ matrix.target.cpu }}
+
+      - name: Setup Nim from a dated nightly
+        # The fallback path. Does what `setup-nim` does — unpack the archive into
+        # `nim/` stripping its one top-level directory, then put `nim/bin` and
+        # nimble's bin on PATH — for the one tag it cannot ask for. The action's
+        # third step, its problem matcher, is inside the action and stays behind;
+        # it only annotates compiler diagnostics in the run log.
+        if: steps.nim.outputs.alias != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p nim
+          cd nim
+          url='${{ steps.nim.outputs.url }}'
+          archive=${url##*/}
+          curl -fsSL -o "$archive" "$url"
+          if [[ $archive == *.zip ]]; then
+            tmp=$(mktemp -d)
+            7z x "$archive" "-o$tmp" > /dev/null
+            extracted=( "$tmp"/* )
+            mv "${extracted[0]}"/* .
+            rm -rf "$tmp"
+          else
+            tar -xf "$archive" --strip-components 1
+          fi
+          rm -f "$archive"
+          nimbin=$(cd bin && pwd -P)
+          nimblebin="$HOME/.nimble/bin"
+          if [ '${{ runner.os }}' = Windows ]; then
+            nimbin=$(cygpath -aw "$nimbin")
+            nimblebin=$(cygpath -aw "$nimblebin")
+          fi
+          echo "$nimbin" >> "$GITHUB_PATH"
+          echo "$nimblebin" >> "$GITHUB_PATH"
+          # `sed -n 1p`, not `head -1`: head closes the pipe on line two and the
+          # shell runs with `pipefail`, so the SIGPIPE would fail this step over a
+          # log line.
+          "$PWD/bin/nim" --version | sed -n 1p
 
       - name: Checkout Nimony
         uses: actions/checkout@v7

--- a/src/arkham/core/peephole.nim
+++ b/src/arkham/core/peephole.nim
@@ -26,6 +26,14 @@
 ## degenerate (straight-line) case of that — it never merges branches — so a
 ## fact lives only inside one sibling list, and the liveness question it needs
 ## is answered from the whole proc, not from the window.
+##
+## "From the whole PROC" is load-bearing and was not free: the scratch names are
+## `tmpN.0`, and the counter behind them RESTARTS in every proc, so one SymId is
+## every proc's `tmp0.0` at once. Answered from the whole buffer, `deadAfter`
+## reads the next proc's `(rebind :tmp0.0 …)` — a definition, therefore benign —
+## as proof that THIS proc's `tmp0.0` is dead, and folds away a store the value
+## is still read from. `procLimit` is what confines the answer; see it for what
+## that miscompiled.
 
 import std / [tables, assertions]
 import nifcore
@@ -60,13 +68,15 @@ proc collectOccs(buf: var TokenBuf; c: var Cursor; parentIsKill: bool; occs: var
   else:
     inc c
 
-proc deadAfter(occs: Occs; s: SymId; pos: int): bool =
-  ## Is `s` dead after token `pos`? True when its next mention is not a read.
-  ## Conservative by construction: an unknown symbol, or one whose next mention
-  ## is a plain operand, answers false.
+proc deadAfter(occs: Occs; s: SymId; pos, limit: int): bool =
+  ## Is `s` dead after token `pos`, asking only up to `limit` (the end of the
+  ## enclosing proc)? True when its next mention there is not a read.
+  ## Conservative by construction: an unknown symbol, one whose next mention is
+  ## a plain operand, and one with no further mention IN THIS PROC all answer
+  ## false.
   let lst = occs.getOrDefault(s)
   for o in lst:
-    if o.pos > pos: return o.benign
+    if o.pos > pos: return o.pos < limit and o.benign
   false                       # nothing follows: the binding outlives the proc's
                               # view here, so do not assume it is dead
 
@@ -114,21 +124,28 @@ proc movFromSym(buf: var TokenBuf; c: Cursor; src: SymId; destNode: var Cursor):
   result = not b.hasMore
 
 proc trList(buf: var TokenBuf; c: var Cursor; dest: var TokenBuf; occs: Occs;
-            folded: var int)
+            limit: int; folded: var int)
 
 proc trNode(buf: var TokenBuf; c: var Cursor; dest: var TokenBuf; occs: Occs;
-            folded: var int) =
+            limit: int; folded: var int) =
   if c.kind == TagLit:
+    # A `(proc …)` head is where the scratch-name counter restarts, so it is
+    # also where the liveness question has to stop looking: everything inside
+    # this subtree asks about `tmp0.0` and means THIS proc's.
+    let inner =
+      if buf.tags.tagName(c.cursorTagId) == "proc":
+        cursorToPosition(buf, c) + subtreeWidth(c)
+      else: limit
     dest.openTag c.cursorTagId
     c.loopInto:
-      trList(buf, c, dest, occs, folded)
+      trList(buf, c, dest, occs, inner, folded)
     dest.closeTag()
   else:
     dest.addSubtree c
     inc c
 
 proc trList(buf: var TokenBuf; c: var Cursor; dest: var TokenBuf; occs: Occs;
-            folded: var int) =
+            limit: int; folded: var int) =
   ## One step of a sibling walk, with the one-node lookahead the rules need.
   var dst: SymId
   var immNode: Cursor
@@ -143,7 +160,7 @@ proc trList(buf: var TokenBuf; c: var Cursor; dest: var TokenBuf; occs: Occs;
        immFoldable(immNode) and
        # PAST the consumer, not at it: the consumer's own source operand is a
        # mention of `dst`, and asking from its start position finds that one.
-       deadAfter(occs, dst, cursorToPosition(buf, la) + subtreeWidth(la) - 1):
+       deadAfter(occs, dst, cursorToPosition(buf, la) + subtreeWidth(la) - 1, limit):
       # `(mov D imm)` + `(mov X D)` with D dead ⇒ `(mov X imm)`. The scratch
       # register's `(rebind …)` above stays: it is a naming directive, costs no
       # machine code, and its `(kill …)` below still balances it.
@@ -155,7 +172,7 @@ proc trList(buf: var TokenBuf; c: var Cursor; dest: var TokenBuf; occs: Occs;
       skip c                 # the materializing mov
       skip c                 # the consumer
       return
-  trNode(buf, c, dest, occs, folded)
+  trNode(buf, c, dest, occs, limit, folded)
 
 proc peephole*(buf: var TokenBuf; immAnyDest: bool): int =
   ## Rewrite `buf` in place; returns the number of instructions removed.
@@ -179,7 +196,7 @@ proc peephole*(buf: var TokenBuf; immAnyDest: bool): int =
   block:
     var c = beginRead(buf)
     while c.hasMore:
-      trList(buf, c, res, occs, result)
+      trList(buf, c, res, occs, buf.len, result)
     endRead c
   buf = ensureMove res
   when defined(arkhamPeepDbg):


### PR DESCRIPTION
The `(mov D imm)` + `(mov X D)` fold asks whether `D` is dead past the consumer, and read the answer out of an occurrence table built over the whole module buffer. The scratch names it asks about are `tmpN.0` and the counter behind them restarts in every proc, so one SymId is every proc's `tmp0.0` at once: the next proc's `(rebind :tmp0.0 …)` — a definition, therefore benign — came back as proof that THIS proc's `tmp0.0` was dead. The materializing `mov` then went away while a later `(rebind :tmpM.0 … (r10))` in the same proc was still reading the value out of that register, and the register held whatever the caller left in it.

What it looks like: locals written inside a loop read back as the values they were initialized to.

    proc g*(p: string): int =
      var pathEnd = -1
      var extPos = p.len
      for i in countdown(p.len-1, 1):
        if p[i] == '.':
          if extPos == p.len: extPos = i
        elif p[i] == '/':
          pathEnd = i
          break
      echo pathEnd, " ", extPos     # 7 11 as a main module, -1 15 imported

Only when imported, because a main module is the last one in its buffer and has no next proc to borrow an answer from. Drop either the `elif` branch or the `break` and the fold is never offered. Found through nimony's joined test groups, which are the only thing that compiles a test as an import; its `tests/nimony/arc/tsplitfile` and `tests/nimony/strings/tsplit_and_append` both run that scan and both printed the pre-loop values.

The pass' own docstring already said the question is answered "from the whole proc" — `procLimit` is that, made true.