### PR TITLE
Fixed the link to leng-spec.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ into a running executable with no external toolchain: no GNU assembler, no
 system linker, no LLVM.
 
 `nimony n` uses it as its all-native code path. Leng itself is specified in
-nimony's [doc/leng-spec.md](https://github.com/nim-lang/nimony/blob/master/doc/leng-spec.md).
+nimony's [doc/leng-spec.md](https://github.com/nim-lang/nimony/blob/master/doc/internals/leng-spec.md).
 
 ## The pipeline
 


### PR DESCRIPTION
The correct link for the leng-spec.md file is : https://github.com/nim-lang/nimony/blob/master/doc/internals/leng-spec.md

It looks like you guys somehow put leng in internals of the nimony repo, but forgot about it kinda