### PR TITLE
arkham: size a float op by its own type, and fold literal conversions

### DIFF
--- a/src/arkham/risc/value.nim
+++ b/src/arkham/risc/value.nim
@@ -2113,8 +2113,9 @@ proc emitFBinE*(g: var CodeGen; c: Cursor; dest: var Location) =
     if acc.kind != InFReg: acc = g.takeFTmp(fslot)
     if acc.kind == NamedStack and acc.spillTemp:
       g.produceIntoFMem2(c, acc); dest = acc; return
-    let bits = if acc.typ.size == 4: 32 else: 64
+    let bits = if fslot.size == 4: 32 else: 64      # the OP's width, never the temp's
     var rdst = acc
+    rdst.typ = fslot                                  # a literal operand materializes at it
     g.emitFValue2(rhsC, rdst)                          # rhs → the accumulator
     if acc.isTemp and not g.rb.isBoundFTmp(acc.f): g.bindFTmp(acc.f, bits)
     if lHome.kind == InFReg:
@@ -2130,8 +2131,12 @@ proc emitFBinE*(g: var CodeGen; c: Cursor; dest: var Location) =
   if dest.kind == NamedStack and dest.spillTemp:
     g.produceIntoFMem2(c, dest); return
   let res = dest
-  let bits = if res.typ.size == 4: 32 else: 64
+  # The width is the operation's, from its result type, not the temp's the
+  # consumer passed (see the x64 twin: a generic 8-byte temp made a float32
+  # multiply a double op over a single-materialized literal).
+  let bits = if fslot.size == 4: 32 else: 64
   var lD = res
+  lD.typ = fslot
   g.emitFValue2(lhsC, lD)                              # a → the result register
   if res.isTemp and not g.rb.isBoundFTmp(res.f): g.bindFTmp(res.f, bits)
   if rhsC.kind == Symbol and g.plan.locationOfSym(symName(rhsC), cursorToPosition(g.buf[], rhsC)).kind == InFReg:

--- a/src/arkham/x64/value.nim
+++ b/src/arkham/x64/value.nim
@@ -2834,8 +2834,9 @@ proc emitFBinE*(g: var CodeGen; c: Cursor; dest: var Location) =
     if acc.kind != InFReg: acc = g.takeFTmp(fslot)
     if acc.kind == NamedStack and acc.spillTemp:
       g.produceIntoFMem2(c, acc); dest = acc; return
-    let bits = if acc.typ.size == 4: 32 else: 64
+    let bits = if fslot.size == 4: 32 else: 64        # the OP's width, never the temp's
     var rdst = acc
+    rdst.typ = fslot                                    # a literal operand materializes at it
     g.emitFValue2(rhsC, rdst)                            # rhs → the accumulator
     if acc.isTemp and not g.rb.isBoundFTmp(acc.f): g.bindFTmp(acc.f)
     if lHome.kind == InFReg:
@@ -2853,8 +2854,13 @@ proc emitFBinE*(g: var CodeGen; c: Cursor; dest: var Location) =
   if dest.kind == NamedStack and dest.spillTemp:
     g.produceIntoFMem2(c, dest); return
   let res = dest
-  let bits = if res.typ.size == 4: 32 else: 64
+  # The width is the operation's, from its result type: `res` is whatever xmm
+  # temp the consumer passed, often a generic 8-byte one, and sizing by it
+  # emitted `mulsd` for a float32 multiply while the literal operand had been
+  # materialized as a single (`y * 2.0'f32` came out 0.0).
+  let bits = if fslot.size == 4: 32 else: 64
   var lD = res
+  lD.typ = fslot
   g.emitFValue2(lhsC, lD)                                # a → the result xmm
   if res.isTemp and not g.rb.isBoundFTmp(res.f): g.bindFTmp(res.f)
   if rhsC.kind == Symbol and g.plan.locationOfSym(symName(rhsC), cursorToPosition(g.buf[], rhsC)).kind == InFReg:
@@ -2875,6 +2881,14 @@ proc emitFBinE*(g: var CodeGen; c: Cursor; dest: var Location) =
       g.fbin(op32, op64, res.f, fs2, bits)
       g.rb.unsealF fs2
   dest = res
+
+
+proc isFloatLitTree(c: Cursor): bool =
+  ## A float literal, possibly under `(suf …)`/`(par …)` wrappers — the shape a
+  ## typed literal (`2.0'f32`) arrives in.
+  var cc = c
+  while cc.kind == TagLit and cc.exprKind in {SufC, ParC}: inc cc
+  result = cc.kind == FloatLit
 
 proc emitCast2*(g: var CodeGen; c: Cursor; dest: var Location) =
   ## FUSED `(conv|cast Type inner)`. Decisions inline (allocValue CastC/ConvC):
@@ -2910,9 +2924,24 @@ proc emitCast2*(g: var CodeGen; c: Cursor; dest: var Location) =
     let dstBits = if slotOf(g.prog, targetCur).size == 4: 32 else: 64
     if g.isFloatExpr(inner):
       var fv = res                                       # dest-pass into the operand
-      g.emitFValue2(inner, fv)
-      if res.isTemp and not g.rb.isBoundFTmp(res.f): g.bindFTmp(res.f)
-      g.emFcvt(res.f, res.f, dstBits, g.floatBits(inner))
+      if isFloatLitTree(inner):
+        # A literal is materialized straight at the TARGET width — the value
+        # is converted at compile time, as a C compiler folds `(float)2.0` —
+        # and there is nothing left to convert at run time. Doing both was the
+        # bug: the `FloatLit` arm sized the constant by `fv`'s slot (the
+        # target's), so a float64 literal bound for float32 was already a
+        # single when `cvtsd2ss` read it as a double: `let x: float32 = 2.0`
+        # gave 0.0 on this backend.
+        fv.typ = slotOf(g.prog, targetCur)
+        g.emitFValue2(inner, fv)
+        if res.isTemp and not g.rb.isBoundFTmp(res.f): g.bindFTmp(res.f)
+      else:
+        # A computed operand is produced at ITS OWN width, then converted.
+        let srcBits = g.floatBits(inner)
+        fv.typ = AsmSlot(cls: AFloat, size: srcBits div 8, align: srcBits div 8)
+        g.emitFValue2(inner, fv)
+        if res.isTemp and not g.rb.isBoundFTmp(res.f): g.bindFTmp(res.f)
+        g.emFcvt(res.f, res.f, dstBits, srcBits)
     else:
       var iv = needsReg(ScalarSlot)
       g.emitValue2(inner, iv)


### PR DESCRIPTION
Branch: fix/x64-float32-width on tokyovigilante/nativenif (2 commits e30d1f2 + 9dab2f3, rebased onto 996b8d9 = master after #152)

Two ways a float32 value came out as 0.0 on the native backend while the C
backend was right:

- `emitFBinE` sized the operation by the xmm temp the consumer passed in,
  often a generic 8-byte one, so a float32 multiply became `mulsd` over a
  literal operand that had been materialized as a single: `y * 2.0'f32`
  printed 0.0.
- A conversion materialized a literal at the target width (the `FloatLit`
  arm sizes a constant by its destination slot) and then converted it again
  from the literal's own width, so `cvtsd2ss` read a single's bit pattern as
  a double: `let x: float32 = 2.0` and any untyped literal passed to a
  float32 parameter gave 0.0.

Fix: the op's width comes from its result type and both operand
destinations carry it; a literal under a conversion is folded at the target
width with no run-time convert, and a computed operand is produced at its
own width, then converted.

Repro (five cases, C backend 4.0 4.0 4.0 3.0 3.0; native gave 0.0 for the
first, second and last):

    import std/syncio
    proc twice(a: float32): float32 = a + a
    proc id32(a: float32): float32 = a
    let x: float32 = 2.0
    echo x + x
    echo twice(2.0)
    echo twice(2.0'f32)
    echo id32(float32(3))
    var y = 1.5'f32
    echo y * 2.0'f32

Second commit mirrors the `emitFBinE` change on a64, which has the same
shape; its conversion path already materializes a literal at its own width
and converts, so it is untouched. Mirrored by reading, not by running — no
arm64 host here, so CI is the check for that commit.

Verified on x64 after rebasing onto master (996b8d9, post-#152): the repro
prints the C backend's five values; nimony's `hastur native` curated set is
116/116 on a clean cache (tclosure_capture_multiname was the failing one).