### PR TITLE
arkham/nifasm: real thread-locals on win_x64

### DIFF
--- a/src/arkham/core/programs.nim
+++ b/src/arkham/core/programs.nim
@@ -677,13 +677,16 @@ proc collect*(buf: var TokenBuf; inputPath: string; tags: TagPool;
       if c.stmtKind in {GvarS, TvarS, ConstS}:
         let gStart = c
         var gc = c
-        # On Windows a thread-local is collected as an ORDINARY global: the PE image
-        # is single-threaded (the native backend spawns no threads) and Win64 has no
-        # counterpart to the FS-based `arkham.tls.0` block the Linux target points at
-        # — GS holds the TEB, whose layout nifasm does not model. Demoting it here
-        # (rather than at each use) is what keeps every downstream `scTvar` dispatch —
-        # `emTvarAddr`, the `Tvar` location arms, `genTvar` — off the Windows path.
-        let isTvar = c.stmtKind == TvarS and not windows
+        # A thread-local is a thread-local on every target, Windows included.
+        #
+        # It was collected as an ORDINARY GLOBAL here on the premise that "the PE
+        # image is single-threaded (the native backend spawns no threads)". That was
+        # never true — `std/rawthreads` calls `CreateThread` and `std/threadpool`
+        # spawns one worker per core — so what the demotion actually did was give
+        # every thread ONE shared copy of every thread-local, silently. Including
+        # `system/memory.allocator`, i.e. one unlocked heap region for all threads.
+        # See `x64/mem.emTvarAddr` for how Windows reaches the real per-thread block.
+        let isTvar = c.stmtKind == TvarS
         gc.into:
           let nm = symName(gc); inc gc
           if isTvar: result.tvars[nm] = gStart   # thread-local (macOS TLV)

--- a/src/arkham/core/typenav.nim
+++ b/src/arkham/core/typenav.nim
@@ -61,12 +61,10 @@ proc lookupSym*(tc: TypeCtx; nm: string): SymInfo =
     case d.stmtKind
     of ProcS: return SymInfo(cat: scProc, asmName: nm)   # foreign proc: its fully-qualified NIF name
     of TvarS:
-      # A FOREIGN thread-local must be classified exactly as its OWNING module
-      # classified its own — and on Windows `collect` demotes every thread-local to
-      # an ordinary global, so that module emitted a `(gvar …)` for it. Reading it
-      # back as a thread-local here would address it through an FS block the target
-      # does not have, against a symbol nifasm knows as a global.
-      if tc.prog[].windows: return SymInfo(cat: scGlobal, decl: d)
+      # A FOREIGN thread-local is classified exactly as its OWNING module
+      # classified its own, on every target: `collect` emits a `(tvar …)`
+      # everywhere now, so reading one back as a global here would address the
+      # main thread's copy — the very bug the Windows demotion used to cause.
       return SymInfo(cat: scTvar, decl: d)
     else: return SymInfo(cat: scGlobal, decl: d)
 

--- a/src/arkham/x64/machine.nim
+++ b/src/arkham/x64/machine.nim
@@ -230,6 +230,16 @@ const Win64EntrySaved* = [RDI, RSI]
 
 const TlsBlockName* = "arkham.tls.0"
 const TlsSelfName* = "arkham.tls.self.0"
+const TlsIndexName* = "arkham.tlsindex.0"
+  ## Windows only. The nifasm-owned 8-byte global the LOADER fills with this
+  ## image's TLS slot number — the index into the per-thread block-pointer array
+  ## the TEB carries. See `emTvarAddr`; nifasm names its address in the PE TLS
+  ## directory (`AddressOfIndex`).
+const TebTlsPtrName* = "arkham.teb.tlsptr.0"
+  ## Windows only, and not a variable: the TEB field `gs:0x58`,
+  ## `ThreadLocalStoragePointer`, spelled as a nifasm-owned thread-local so the
+  ## assembler's segment-operand path encodes it. Reading it yields the head of
+  ## this thread's array of static-TLS block pointers.
   ## The thread-local at offset 0 of every thread's block, holding that block's own
   ## address. Reading it is how `&threadvar` finds THIS thread's storage — see
   ## `emTvarAddr`.

--- a/src/arkham/x64/mem.nim
+++ b/src/arkham/x64/mem.nim
@@ -224,6 +224,30 @@ proc emTvarAddr*(g: var CodeGen; dest: Reg; name: string) =
   ## environment threadvar): nifasm whole-program-links, so its lea offset resolver
   ## (`lookupWithAutoImport`) imports the foreign `(tvar …)` decl and allocates its FS
   ## offset in the SAME unified `arkham.tls.0` block. Local and foreign emit identically.
+  if g.prog.windows:
+    # Windows finds the block through the loader instead. A PE image's static
+    # thread-locals live in a block the loader COPIES from the `.tls` template for
+    # every thread it ever creates, and it leaves the copy's address in
+    #     TEB->ThreadLocalStoragePointer[ *arkham.tlsindex.0 ]
+    # with the TEB at GS and that array's head at `gs:0x58`. So there is no
+    # per-thread setup anywhere — a thread has its thread-locals before its first
+    # instruction — at the price of two loads to reach the block. Everything is
+    # staged through `dest` so this needs no scratch register, which is what lets
+    # it be called from inside an address computation that has already spent its
+    # staging budget. (See `nifasm/driver.setupTlsWin` for the other half.)
+    # `dest` carries a raw address while the block is being walked to: the two
+    # loads and the shift are integer arithmetic, and a `dest` still bound as
+    # `(ptr T)` would make nifasm reject the `shl`. The caller rebinds it to the
+    # pointer type it wants once the address is formed (`winTvarPtr`); both
+    # rebinds are zero machine code.
+    g.releaseStaleName(dest)
+    g.bindTemp(dest, AddrSlot)
+    g.ab.tree GloadX64: (g.emReg dest; g.ab.sym TlsIndexName)      # dest ← our TLS index
+    g.binImm(ShlX64, dest, 3)                                      # dest ← index * 8
+    g.ab.tree AddX64: (g.emReg dest; g.ab.sym TebTlsPtrName)       # dest += gs:[0x58]
+    g.ab.tree MovX64: (g.emReg dest; g.ab.tree MemX: g.emReg dest) # dest ← this thread's block
+    g.ab.tree LeaX64: (g.emReg dest; g.emReg dest; g.ab.sym name)  # dest += tvar offset
+    return
   g.ab.tree MovX64: (g.emReg dest; g.ab.sym TlsSelfName)         # dest ← FS:[0], this thread's block
   g.ab.tree LeaX64: (g.emReg dest; g.emReg dest; g.ab.sym name)  # dest += tvar FS offset
 

--- a/src/arkham/x64/value.nim
+++ b/src/arkham/x64/value.nim
@@ -112,6 +112,40 @@ when not defined(arkhamNoNarrowHomes):
 # regbind.nim / codegen_common.nim; these are the two doors the x86-64 emitter
 # uses them through.
 
+proc winTvarPtr(g: var CodeGen; loc: Location; what: string): Reg =
+  ## `&threadvar` in a staging register, typed `(ptr T)` so the `(mem p)` deref
+  ## carries the thread-local's PRECISE type (nifasm is strict — same reason the
+  ## `Glob` arms below type their address temp).
+  ##
+  ## Windows only, and unconditional there: a PE thread-local has no folded
+  ## segment form. The loader puts each thread's block where it likes and records
+  ## the address in the TEB, so every access materialises it (`emTvarAddr`).
+  ## nifasm REFUSES the `fs:[off]` operand on win_x64, so a site that forgets this
+  ## fails to assemble instead of reading an unrelated address.
+  var pSlot = ScalarSlot
+  if not cursorIsNil(loc.typ.typ):
+    pSlot = typeToSlot(g.prog.ptrTypeOf(loc.typ.typ))
+  result = g.pickStagingSealed(what, pSlot)
+  g.emTvarAddr(result, loc.name)
+  # `emTvarAddr` left it bound as a raw address (it does arithmetic on the way to
+  # the block); the deref below wants the thread-local's precise pointee type.
+  g.releaseStaleName(result)
+  g.bindTemp(result, pSlot)
+
+proc winTvarMov(g: var CodeGen; loc: Location; reg: Reg; load: bool) =
+  ## A thread-local GPR scalar access on Windows: address, then deref.
+  let p = g.winTvarPtr(loc, (if load: "a thread-local load address"
+                             else: "a thread-local store address"))
+  if load:
+    g.ab.tree MovX64:
+      g.emReg reg
+      g.ab.tree MemX: g.emReg p
+  else:
+    g.ab.tree MovX64:
+      g.ab.tree MemX: g.emReg p
+      g.emReg reg
+  g.giveBack p
+
 proc scalarMemMov(g: var CodeGen; loc: Location; reg: Reg; load: bool) =
   ## The one GPR scalar memory move over every lvalue kind, both directions:
   ## `load` → `reg ← <loc>`; else `<loc> ← reg`. Load and store are mirror images
@@ -124,10 +158,13 @@ proc scalarMemMov(g: var CodeGen; loc: Location; reg: Reg; load: bool) =
   case loc.kind
   of InReg:
     if load: g.movReg(reg, loc.r) else: g.movReg(loc.r, reg)
-  of Tvar:                                        # nifasm resolves a tvar to FS:[off]
-    g.ab.tree MovX64:
-      if load: (g.emReg reg; g.ab.sym loc.name)
-      else:    (g.ab.sym loc.name; g.emReg reg)
+  of Tvar:
+    if g.prog.windows:                            # no folded form — see `winTvarPtr`
+      g.winTvarMov(loc, reg, load)
+    else:                                         # nifasm resolves a tvar to FS:[off]
+      g.ab.tree MovX64:
+        if load: (g.emReg reg; g.ab.sym loc.name)
+        else:    (g.ab.sym loc.name; g.emReg reg)
   of Glob:
     if g.globalFoldsIntoAccess(loc.name):
       # The address folds INTO the access: one RIP-relative `mov` instead of an
@@ -243,11 +280,23 @@ proc floatMemMov(g: var CodeGen; loc: Location; reg: FReg; bits: int; load: bool
   of NamedStack:
     if load: g.emFloatScalarLoad(reg, loc.name, bits)
     else:    g.emFloatScalarStore(loc.name, reg, bits)
-  of Tvar:                                        # nifasm resolves a tvar to FS:[off]
+  of Tvar:
     let op = if bits == 32: MovssX64 else: MovsdX64
-    g.ab.tree op:
-      if load: (g.emFReg reg; g.ab.sym loc.name)
-      else:    (g.ab.sym loc.name; g.emFReg reg)
+    if g.prog.windows:                            # no folded form — see `winTvarPtr`
+      let p = g.winTvarPtr(loc, "a thread-local float address")
+      if load:
+        g.ab.tree op:
+          g.emFReg reg
+          g.ab.tree MemX: g.emReg p
+      else:
+        g.ab.tree op:
+          g.ab.tree MemX: g.emReg p
+          g.emFReg reg
+      g.giveBack p
+    else:                                         # nifasm resolves a tvar to FS:[off]
+      g.ab.tree op:
+        if load: (g.emFReg reg; g.ab.sym loc.name)
+        else:    (g.ab.sym loc.name; g.emFReg reg)
   of Glob:
     # &g into a typed staging GPR, then movss/movsd through it. The address temp is
     # `(ptr <floatType>)` so the `(mem p)` deref yields the float's precise width.
@@ -1800,10 +1849,13 @@ proc genStore2*(g: var CodeGen; rhs: Cursor; dst: Location) =
       v = regLoc(glbStaging, v.typ)
     assert v.kind == InReg, "arkham x64n: global store rhs " & $v.kind
     case dst.kind
-    of Tvar:                                             # nifasm resolves FS:[off]
-      g.ab.tree MovX64:
-        g.ab.sym dst.name
-        g.emReg v.r
+    of Tvar:
+      if g.prog.windows:                                 # no folded form
+        g.winTvarMov(dst, v.r, load = false)
+      else:                                              # nifasm resolves FS:[off]
+        g.ab.tree MovX64:
+          g.ab.sym dst.name
+          g.emReg v.r
     of Glob:                                             # &g into a transient, then store
       if g.globalFoldsIntoAccess(dst.name):
         g.ab.tree GstoreX64: (g.emReg v.r; g.ab.sym g.prog.gvarRefName(dst.name))

--- a/src/nifasm/core/context.nim
+++ b/src/nifasm/core/context.nim
@@ -306,6 +306,27 @@ type
                                   # final after the last module's tvars are allocated).
     tlsSizeLabel*: LabelId        # its label in `buf`
     tlsSizeUsed*: bool            # something referenced it, so `appendTlsSize` runs
+    # ── Windows thread-locals ──
+    # The PE target cannot use the FS block above: GS holds the TEB, whose layout
+    # nifasm does not own. It uses the mechanism the loader already provides —
+    # static TLS. `.tls` carries a TEMPLATE of one thread's block; the loader
+    # copies it for every thread the process ever creates (`CreateThread` included)
+    # and leaves a pointer to that copy in
+    # `TEB->ThreadLocalStoragePointer[*AddressOfIndex]`. So `&threadvar` is
+    #     gs:[0x58]  →  [+ arkham.tlsindex.0 * 8]  →  + the tvar's offset
+    # and nothing has to run per thread. See `setupTlsWin`.
+    winTlsTemplate*: seq[byte]    # one thread's block as it starts out: `tlsOffset`
+                                  # bytes with every `tlsInits` literal baked in
+    winTlsIndexSym*: Symbol       # `arkham.tlsindex.0`, the 8-byte `.bss` cell the
+                                  # loader fills with this image's TLS index. Eight
+                                  # and not four so arkham can load it with an
+                                  # ordinary 64-bit `mov`: the loader writes only the
+                                  # low DWORD and the slot starts zeroed, so the high
+                                  # half stays 0 and the value needs no extension.
+    winTebTlsPtrSym*: Symbol      # `arkham.teb.tlsptr.0` — not a variable at all but
+                                  # the fixed TEB field `gs:0x58`, spelled as a tvar
+                                  # so the existing segment-operand path encodes it
+                                  # (`Symbol.gsFixedSlot`).
     entrySym*: Symbol             # the entry proc (`_start`/`main.0`) — prologue jumps here
     entryStubOffset*: int          # .text offset of the synthesized ELF entry stub, or -1.
                                   # x86-64: the FS-setup prologue (setupTls); AArch64:

--- a/src/nifasm/core/sem.nim
+++ b/src/nifasm/core/sem.nim
@@ -123,6 +123,12 @@ type
     reg*: TagEnum     # For var/param in register (e.g. RaxTagId)
     offset*: int      # Stack offset, label position, or field offset
     size*: int        # For stack slots
+    gsFixedSlot*: bool ## skTvar only, Windows only: this is not a slot in a block
+                       ## nifasm lays out but a FIXED field of the TEB, reached
+                       ## through GS instead of FS. The one instance is
+                       ## `arkham.teb.tlsptr.0` = `gs:0x58`, the loader's
+                       ## `ThreadLocalStoragePointer`, which is where the PE
+                       ## static-TLS block for this thread is found.
     dataConst*: bool  # skRodata only: this `const` blob has symbol-pointer fields
                       # (`(reloc ...)`), so it must live in writable __DATA and be
                       # rebased by dyld at load (Mach-O). Plain consts stay in __TEXT.

--- a/src/nifasm/core/typesem.nim
+++ b/src/nifasm/core/typesem.nim
@@ -303,8 +303,10 @@ proc resolveForeignSym(ctx: var GenContext; modname, fullName: string; scope: Sc
     result = Symbol(name: ctx.symIdOf(fullName), kind: skTvar, typ: typ, isForeign: true,
                     moduleName: modname)
     ctx.rootScope.define(result)
-    # x86-64 bakes a thread-local's FS displacement at every *reference* site (no
-    # relocation), so the offset must be fixed BEFORE the first reference. A
+    # x86-64 bakes a thread-local's displacement at every *reference* site (no
+    # relocation) — the FS displacement on Linux, the offset into the loader's
+    # per-thread block on Windows — so the offset must be fixed BEFORE the first
+    # reference. A
     # reference resolves the symbol through here first, so allocate the FS offset
     # eagerly now — exactly like the main-module tvar pre-pass — and mark it
     # generated so `generateSymbol` does not re-allocate (which would advance
@@ -315,7 +317,8 @@ proc resolveForeignSym(ctx: var GenContext; modname, fullName: string; scope: Sc
     # and the real offset into later ones — a size field then aliases what a pointer
     # field should be. (macOS/A64 relocates tvars through descriptors and allocates
     # lazily in `generateSymbol`, so leave that path untouched.)
-    if ctx.arch == Arch.X64 and ctx.nameOf(result.name) notin ctx.generatedSymbols:
+    if ctx.arch in {Arch.X64, Arch.WinX64} and
+       ctx.nameOf(result.name) notin ctx.generatedSymbols:
       allocTlsSlotX64(ctx, result, declStartCur)
       ctx.generatedSymbols.incl ctx.nameOf(result.name)
   of RodataD:

--- a/src/nifasm/driver.nim
+++ b/src/nifasm/driver.nim
@@ -316,6 +316,33 @@ proc setupTls(ctx: var GenContext) =
                                                        scale: 8, displacement: 8'i32, hasIndex: true))  # rdx = &envp[0]
   x86.emitJmp(ctx.buf, LabelId(ctx.entrySym.offset))        # → real entry
 
+proc setupTlsWin(ctx: var GenContext) =
+  ## Windows thread-locals. Where `setupTls` reserves one `.bss` block and points
+  ## FS at it per thread, this hands the whole job to the loader: `.tls` carries a
+  ## TEMPLATE of one thread's block, and the loader copies it for every thread the
+  ## process ever creates — `CreateThread`'d ones included — leaving a pointer to
+  ## that copy in `TEB->ThreadLocalStoragePointer[*AddressOfIndex]`. So there is no
+  ## entry prologue here and no per-thread hook anywhere: a thread has its
+  ## thread-locals before it runs its first instruction.
+  ##
+  ## The tvar offsets themselves are the ones `allocTlsSlotX64` already handed out;
+  ## the template is indexed by exactly those, so `arkham.tls.self.0` still owns
+  ## offset 0 (unused here — Windows finds the block through the TEB, not through a
+  ## self-pointer) and every real tvar sits where its `lea` says it does.
+  if ctx.arch != Arch.WinX64 or ctx.tlsOffset == 0: return
+  if ctx.winTlsIndexSym == nil: return
+  ctx.winTlsTemplate = newSeq[byte]((ctx.tlsOffset + 15) and not 15)
+  for it in ctx.tlsInits:
+    for i in 0 ..< it.size:
+      let at = it.off.int + i
+      if at < ctx.winTlsTemplate.len:
+        ctx.winTlsTemplate[at] = byte((it.val shr (8 * i)) and 0xFF)
+  # The index cell is an ordinary writable global; the loader fills it before any
+  # of our code runs. 8-byte aligned so arkham's 64-bit load of it is aligned.
+  ctx.bssOffset = (ctx.bssOffset + 7) and not 7
+  ctx.winTlsIndexSym.size = ctx.bssOffset
+  ctx.bssOffset += TlsIndexCellBytes
+
 proc assemble*(filename, outfile: string; symMap = false; emitObj = false;
                listing = ""; debugInfo = true;
                memMap = elf32.defaultMemoryMap()) =
@@ -380,6 +407,28 @@ proc assemble*(filename, outfile: string; symMap = false; emitObj = false;
   scope.define(ctx.tlsSelfSym)
   ctx.generatedSymbols.incl TlsSelfSymbol
 
+  # The Windows pair. Both are defined unconditionally — the architecture is only
+  # known after `pass1` reads the `(arch …)` directive, and both are inert off
+  # Windows: being generated symbols they are skipped by the tvar offset
+  # allocation below, and nothing but arkham's PE path ever references them.
+  #
+  # `arkham.teb.tlsptr.0` is not a variable. It is the TEB field at `gs:0x58`
+  # spelled as a thread-local so the segment-operand path encodes it, with
+  # `gsFixedSlot` telling that path to use GS and to read `offset` as the TEB
+  # displacement rather than a slot in a block nifasm laid out.
+  ctx.winTebTlsPtrSym = Symbol(name: ctx.symIdOf(TebTlsPtrSymbol), kind: skTvar,
+                               typ: Type(kind: UIntT, bits: 64),
+                               offset: TebTlsPtrOffset, gsFixedSlot: true)
+  scope.define(ctx.winTebTlsPtrSym)
+  ctx.generatedSymbols.incl TebTlsPtrSymbol
+  # `arkham.tlsindex.0` is an ordinary `.bss` global; `setupTlsWin` gives it its
+  # slot once the layout is settled, and the PE TLS directory names its address.
+  ctx.winTlsIndexSym = Symbol(name: ctx.symIdOf(TlsIndexSymbol), kind: skGvar,
+                              typ: Type(kind: UIntT, bits: 64),
+                              size: -1, offset: -1)
+  scope.define(ctx.winTlsIndexSym)
+  ctx.generatedSymbols.incl TlsIndexSymbol
+
   var n1 = beginRead(ctx.modules[MainModuleName].buf)
   pass1(n1, scope, ctx, MainModuleName, ctx.modules[MainModuleName].buf)
 
@@ -388,7 +437,7 @@ proc assemble*(filename, outfile: string; symMap = false; emitObj = false;
   # offset must be fixed before any code is generated — otherwise a reference
   # compiled before the tvar's lazy `generateSymbol` would capture the default 0.
   # (macOS/A64 resolves tvars through relocated descriptors and allocates lazily.)
-  if ctx.arch == Arch.X64:
+  if ctx.arch in {Arch.X64, Arch.WinX64}:
     var tn = beginRead(ctx.modules[MainModuleName].buf)
     if tn.kind == TagLit and tn.tag == StmtsTagId:
       loopInto tn:
@@ -426,6 +475,7 @@ proc assemble*(filename, outfile: string; symMap = false; emitObj = false;
   appendTraceTable(ctx)
   appendTlsSize(ctx)
   setupTls(ctx)
+  setupTlsWin(ctx)
   setupWinEntry(ctx)
   setupLinuxA64Entry(ctx)
 

--- a/src/nifasm/image/pe.nim
+++ b/src/nifasm/image/pe.nim
@@ -370,7 +370,9 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
               dynlink: DynLinkInfo = DynLinkInfo();
               absSites: seq[AbsSite] = @[];
               patch: PePatchProc = nil;
-              unwind: seq[ProcUnwind] = @[]) =
+              unwind: seq[ProcUnwind] = @[];
+              tlsTemplate: seq[byte] = @[];
+              tlsIndexDataOff: int = -1) =
   ## Write a PE executable file.
   ##
   ## `dataImage` is the writable data section's initial contents (`bssSize` bytes; a
@@ -379,6 +381,13 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
   ## into `code`/`dataImage` (globals' RIP-relative `lea` displacements, absolute
   ## function pointers). `absSites` lists the absolute 8-byte fields it writes, so
   ## they can be listed in `.reloc` and survive ASLR.
+  ##
+  ## `tlsTemplate`, when non-empty, is one thread's thread-local block as it starts
+  ## out; it gets a `.tls` section and an `IMAGE_TLS_DIRECTORY64`, and the loader
+  ## then copies it for every thread the process creates — `CreateThread`'d ones
+  ## included — recording the copy's address in
+  ## `TEB->ThreadLocalStoragePointer[*AddressOfIndex]`. `tlsIndexDataOff` is the
+  ## byte offset in `dataImage` of the 8-byte cell that index is written into.
   let hasExtProcs = dynlink.extProcs.len > 0
   let dataSize = uint32(bssSize)
   let hasData = dataSize > 0
@@ -410,11 +419,17 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
   # Calculate number of sections. Every `inc` here MUST have a matching section
   # header written below — a count that overshoots makes the loader read the padding
   # after the real headers as one more section descriptor.
+  # `.tls` sits BEFORE `.reloc` on purpose: the four absolute VAs in its directory
+  # need relocation entries, so its RVA has to be settled before the reloc table is
+  # built. Placed after `.reloc` the two would define each other.
+  let hasTls = tlsTemplate.len > 0 and tlsIndexDataOff >= 0
   var numSections = 1'u16  # .text
   if hasExtProcs:
     inc numSections  # .idata for imports
   if hasData:
     inc numSections  # .data: globals (zero-filled unless statically initialized)
+  if hasTls:
+    inc numSections  # .tls: one thread's block template, plus its directory
   inc numSections  # .reloc for ASLR support
   # `.pdata`: the x64 function table plus the `UNWIND_INFO` blobs it points at.
   # One section for both — the exception directory addresses the table by RVA and
@@ -597,6 +612,23 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
     if dataImage.len < bssSize: dataImage.setLen bssSize      # the rest is zero-filled
     elif dataImage.len > bssSize: dataImage.setLen bssSize
 
+  # `.tls`, whose RVA the reloc table below needs. The section holds the DIRECTORY
+  # first (the loader reads it there), then the one-entry NULL callback array it
+  # has to name, then the template the loader copies per thread:
+  #     0x00  IMAGE_TLS_DIRECTORY64            (40 bytes)
+  #     0x28  a single NULL callback pointer   (8 bytes)
+  #     0x40  the template                     (`tlsTemplate.len` bytes)
+  const TlsDirSize = 40'u32
+  const TlsCallbacksOff = 40'u32
+  const TlsTemplateOff = 64'u32
+  var tlsRva = 0'u32
+  var tlsSize = 0'u32
+  if hasTls:
+    tlsRva = if hasData: alignTo(dataRva + dataSize, SECTION_ALIGNMENT)
+             elif hasExtProcs: alignTo(idataRva + idataSize, SECTION_ALIGNMENT)
+             else: alignTo(textRva + textSize, SECTION_ALIGNMENT)
+    tlsSize = TlsTemplateOff + uint32(tlsTemplate.len)
+
   # The layout is settled: let the caller bake its addresses in before anything is
   # written. Everything else nifasm emits is RIP-relative and needed no layout.
   if patch != nil:
@@ -611,11 +643,17 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
   var relocBytes: seq[byte] = @[]
   block:
     var byPage = initOrderedTable[uint32, seq[uint16]]()
-    for s in absSites:
-      let rva = (if s.inData: dataRva else: textRva) + uint32(s.pos)
+    template noteAbs(rva: uint32) =
       let page = rva and not (SECTION_ALIGNMENT - 1)
       byPage.mgetOrPut(page, @[]).add uint16((IMAGE_REL_BASED_DIR64 shl 12) or
                                              uint16(rva - page))
+    for s in absSites:
+      noteAbs((if s.inData: dataRva else: textRva) + uint32(s.pos))
+    if hasTls:
+      # The directory's first four fields are absolute VAs, not RVAs — the one
+      # place in a PE where that is so, and the reason `.tls` needs entries here
+      # at all. Start/End of the template, the index cell, the callback array.
+      for i in 0'u32 ..< 4'u32: noteAbs(tlsRva + i * 8)
     if byPage.len == 0:
       # No absolute fields at all — emit the one empty block the loader tolerates,
       # so the directory is still valid.
@@ -640,6 +678,8 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
     sizeOfImage = idataRva + alignTo(idataSize, SECTION_ALIGNMENT)
   if hasData:
     sizeOfImage = dataRva + alignTo(dataSize, SECTION_ALIGNMENT)
+  if hasTls:
+    sizeOfImage = tlsRva + alignTo(tlsSize, SECTION_ALIGNMENT)
   # Add .reloc section to image size
   let relocRva = sizeOfImage
   sizeOfImage = relocRva + alignTo(relocSize, SECTION_ALIGNMENT)
@@ -684,6 +724,10 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
     optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT].Size = idataSize
     optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IAT].VirtualAddress = iatRva
     optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IAT].Size = iatSize
+
+  if hasTls:
+    optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].VirtualAddress = tlsRva
+    optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].Size = TlsDirSize
 
   # Set base relocation directory
   optHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC].VirtualAddress = relocRva
@@ -738,12 +782,51 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
       IMAGE_SCN_CNT_INITIALIZED_DATA or IMAGE_SCN_MEM_READ or IMAGE_SCN_MEM_WRITE
     )
 
-  # .reloc section (comes after .data / .idata / .text)
+  # .tls section: the directory, the NULL callback array, then the template.
+  var tlsSection: IMAGE_SECTION_HEADER
+  var tlsFileOffset = 0'u32
+  var tlsRawSize = 0'u32
+  var tlsBytes: seq[byte] = @[]
+  if hasTls:
+    tlsFileOffset = if hasData: dataFileOffset + dataRawSize
+                    elif hasExtProcs: idataFileOffset + idataRawSize
+                    else: textFileOffset + textRawSize
+    tlsBytes = newSeq[byte](tlsSize)
+    let base = DEFAULT_IMAGE_BASE
+    template putQ(at: uint32; v: uint64) =
+      for i in 0 ..< 8: tlsBytes[int(at) + i] = byte((v shr (8 * i)) and 0xFF)
+    # StartAddressOfRawData / EndAddressOfRawData delimit the template; the loader
+    # copies exactly those bytes and then zero-fills `SizeOfZeroFill` more (we bake
+    # every initializer into the template instead, so that stays 0).
+    putQ(0, base + uint64(tlsRva + TlsTemplateOff))
+    putQ(8, base + uint64(tlsRva + TlsTemplateOff) + uint64(tlsTemplate.len))
+    # AddressOfIndex: the cell in `.data` the loader writes this image's TLS slot
+    # number into — the index arkham uses against `gs:[0x58]`.
+    putQ(16, base + uint64(dataRva) + uint64(tlsIndexDataOff))
+    # AddressOfCallBacks must name a NULL-terminated array even when there are no
+    # callbacks, so it points at the eight zero bytes reserved above.
+    putQ(24, base + uint64(tlsRva + TlsCallbacksOff))
+    # SizeOfZeroFill (at 32) and Characteristics (at 36) both stay 0.
+    for i in 0 ..< tlsTemplate.len:
+      tlsBytes[int(TlsTemplateOff) + i] = tlsTemplate[i]
+    tlsRawSize = alignTo(tlsSize, FILE_ALIGNMENT)
+    tlsSection = initSectionHeader(
+      ".tls",
+      tlsSize,
+      tlsRva,
+      tlsRawSize,
+      tlsFileOffset,
+      IMAGE_SCN_CNT_INITIALIZED_DATA or IMAGE_SCN_MEM_READ or IMAGE_SCN_MEM_WRITE
+    )
+
+  # .reloc section (comes after .tls / .data / .idata / .text)
   var relocFileOffset = textFileOffset + textRawSize
   if hasExtProcs:
     relocFileOffset = idataFileOffset + idataRawSize
   if hasData:
     relocFileOffset = dataFileOffset + dataRawSize
+  if hasTls:
+    relocFileOffset = tlsFileOffset + tlsRawSize
   var relocSection = initSectionHeader(
     ".reloc",
     relocSize,
@@ -796,6 +879,8 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
     f.writeData(unsafeAddr idataSection, sizeof(idataSection))
   if hasData:
     f.writeData(unsafeAddr dataSection, sizeof(dataSection))
+  if hasTls:
+    f.writeData(unsafeAddr tlsSection, sizeof(tlsSection))
   f.writeData(unsafeAddr relocSection, sizeof(relocSection))
   if hasPdata:
     f.writeData(unsafeAddr pdataSection, sizeof(pdataSection))
@@ -865,6 +950,14 @@ proc writePE*(code: var Buffer; dataImage: var seq[byte]; bssSize: int;
     if dataPadding > 0:
       var zeros = newSeq[byte](dataPadding)
       f.writeData(unsafeAddr zeros[0], dataPadding)
+
+  # .tls section: directory, NULL callback array, template
+  if hasTls:
+    f.writeData(unsafeAddr tlsBytes[0], tlsBytes.len)
+    let tlsPadding = int(tlsRawSize) - tlsBytes.len
+    if tlsPadding > 0:
+      var zeros = newSeq[byte](tlsPadding)
+      f.writeData(unsafeAddr zeros[0], tlsPadding)
 
   # .reloc section
   f.writeData(unsafeAddr relocBytes[0], relocBytes.len)

--- a/src/nifasm/image/tracetable.nim
+++ b/src/nifasm/image/tracetable.nim
@@ -71,6 +71,24 @@ const
     ## nifasm owns the symbol; the entry prologue fills it for the main thread and
     ## whoever creates a thread fills that thread's.
   TlsSelfSlotBytes* = 8
+  TlsIndexSymbol* = "arkham.tlsindex.0"
+    ## Windows only. The 8-byte `.bss` cell whose address the PE TLS directory
+    ## names as `AddressOfIndex`; the loader writes this image's TLS slot number
+    ## into it before any of our code runs. arkham reads it to find the block:
+    ## `gs:[0x58]` is an ARRAY of per-thread block pointers, one per module with
+    ## static TLS, and this is our index into it.
+    ##
+    ## Eight bytes for a DWORD so an ordinary 64-bit `mov` can load it: the cell
+    ## starts zeroed and the loader writes only the low half, so the high half
+    ## stays zero and no zero-extension is needed.
+  TlsIndexCellBytes* = 8
+  TebTlsPtrSymbol* = "arkham.teb.tlsptr.0"
+    ## Windows only, and not a variable: the fixed TEB field at `gs:0x58`,
+    ## `ThreadLocalStoragePointer`. It is spelled as a thread-local so the
+    ## existing segment-operand path encodes it, and marked `gsFixedSlot` so that
+    ## path picks GS and treats the offset as the TEB displacement rather than a
+    ## slot in a block nifasm laid out.
+  TebTlsPtrOffset* = 0x58
 
 type
   TraceProc* = object

--- a/src/nifasm/image/writepe.nim
+++ b/src/nifasm/image/writepe.nim
@@ -118,5 +118,11 @@ proc writeExe*(a: var GenContext; outfile: string) =
   # `.pdata`/`.xdata` from the same per-proc facts the ELF path encodes as
   # `.eh_frame`. Win64 has no frame pointer either, so this is what lets the OS
   # unwind at all — a backtrace, and any future SEH, both hang off it.
+  # Windows thread-locals, if the image has any: the template one thread's block
+  # starts out as, plus where the loader is to write our TLS index (see
+  # `driver.setupTlsWin`). Empty on every other target, and on a Windows image
+  # with no thread-locals at all.
+  let tlsIndexOff = if a.winTlsIndexSym != nil: a.winTlsIndexSym.size else: -1
   writePE(a.buf, dataImage, a.bssOffset, entryOff, machine, outfile, dynlink,
-          absSites, patchAddrs, (if a.debugInfo: a.unwind else: @[]))
+          absSites, patchAddrs, (if a.debugInfo: a.unwind else: @[]),
+          a.winTlsTemplate, tlsIndexOff)

--- a/src/nifasm/x64/encoder.nim
+++ b/src/nifasm/x64/encoder.nim
@@ -11,6 +11,17 @@ type
     R8 = 8, R9 = 9, R10 = 10, R11 = 11, R12 = 12, R13 = 13, R14 = 14, R15 = 15
 
   # Addressing modes for ModR/M byte
+  SegOverride* = enum
+    ## A legacy segment-override prefix. `segFs` is how the Linux/ELF target
+    ## reaches arkham's own thread-local block (`FS_base + disp32`); `segGs` is
+    ## how the Windows target reaches a FIXED field of the TEB — the loader's
+    ## `ThreadLocalStoragePointer` at `gs:0x58`, which is where a PE image's
+    ## static thread-locals are found. Both encode identically apart from the
+    ## prefix byte.
+    segNone = 0'u8
+    segFs = 0x64'u8
+    segGs = 0x65'u8
+
   AddressingMode* = enum
     amIndirect = 0b00,        # Indirect memory addressing
     amIndirectDisp8 = 0b01,   # Indirect with 8-bit displacement
@@ -27,7 +38,7 @@ type
     noBase*: bool        # `[index*scale + disp32]` with NO base register (SIB
                          # base=101 under mod=00). `base` must be left RAX so the
                          # emitters' REX.B-from-base computations stay silent.
-    useFsSegment*: bool  # Use FS segment register (for thread-local storage)
+    seg*: SegOverride    # segment-override prefix, if any (thread-local storage)
 
 # REX prefix encoding
 type RexPrefix* = object
@@ -62,19 +73,20 @@ proc encodeSIB(scale: int; index: int; base: int): byte =
   byte((scaleBits shl 6) or ((index and 0x07) shl 3) or (base and 0x07))
 
 proc emitSegPrefix(dest: var Bytes; mem: MemoryOperand) =
-  ## A legacy segment-override prefix (FS = 0x64, for thread-local storage) must
+  ## A legacy segment-override prefix (FS = 0x64 / GS = 0x65, for thread-local
+  ## storage) must
   ## precede the REX prefix and opcode, so it is emitted by the instruction
   ## encoder *before* anything else — NOT inside `emitMem` (which runs last, after
   ## REX+opcode are already in `dest`, where the prefix byte would be misplaced).
-  if mem.useFsSegment:
-    dest.add(0x64)  # FS segment override prefix
+  if mem.seg != segNone:
+    dest.add(byte(mem.seg))
 
 proc emitMem(dest: var Bytes; reg: int; mem: MemoryOperand) =
   # A segment-relative (thread-local) operand is displacement-only: the effective
-  # address is `FS_base + disp32`, with NO base/index register — otherwise a frame
+  # address is `SEG_base + disp32`, with NO base/index register — otherwise a frame
   # pointer or any GPR left in `mem.base` would corrupt the address. Encode it as
   # ModRM mod=00 rm=100 (SIB form) + SIB base=101/index=100 (neither) + disp32.
-  if mem.useFsSegment:
+  if mem.seg != segNone:
     dest.add(encodeModRM(amIndirect, reg, 0b100))   # mod=00, rm=100 → SIB follows
     dest.add(encodeSIB(1, 0b100, 0b101))            # index=none, base=none → [disp32]
     dest.addt32(mem.displacement)
@@ -2236,7 +2248,7 @@ proc emitLea*(dest: var Bytes; reg: Register; mem: MemoryOperand) =
   ## instruction count cannot see the difference; the wall clock can. (No FS
   ## override here: `fs:[0+off]` is a real address, and it always carries a
   ## displacement anyway.)
-  if not mem.hasIndex and mem.displacement == 0 and not mem.useFsSegment:
+  if not mem.hasIndex and mem.displacement == 0 and mem.seg == segNone:
     if reg != mem.base: emitMov(dest, reg, mem.base)
     return
   emitSegPrefix(dest, mem)

--- a/src/nifasm/x64/operands.nim
+++ b/src/nifasm/x64/operands.nim
@@ -75,7 +75,7 @@ proc parseOperand*(n: var Cursor; ctx: var GenContext): Operand =
       var baseIndex: x86.Register
       var baseScale = 1
       var baseHasIndex = false
-      var useFsSegment = false
+      var seg = segNone
       var fieldName: string
 
       # Check if first arg is a register (explicit stack addressing)
@@ -123,7 +123,7 @@ proc parseOperand*(n: var Cursor; ctx: var GenContext): Operand =
             baseHasIndex = baseOp.mem.hasIndex
             baseIndex = baseOp.mem.index
             baseScale = baseOp.mem.scale
-            useFsSegment = baseOp.mem.useFsSegment
+            seg = baseOp.mem.seg
           else:
             baseReg = baseOp.reg
         elif baseOp.kind == okMem and baseOp.typ.kind in {TypeKind.ObjectT, TypeKind.UnionT}:
@@ -166,7 +166,7 @@ proc parseOperand*(n: var Cursor; ctx: var GenContext): Operand =
         scale: baseScale,
         displacement: baseDisp + int32(fieldOffset),
         hasIndex: baseHasIndex,
-        useFsSegment: useFsSegment
+        seg: seg
       )
       result.typ = Type(kind: TypeKind.PtrT, base: fieldType)
 
@@ -752,16 +752,27 @@ proc parseOperand*(n: var Cursor; ctx: var GenContext): Operand =
       result.typ = Type(kind: UIntT, bits: 64) # Address of gvar
       inc n
     elif sym != nil and sym.kind == skTvar:
-      # Accessing thread local variable via FS segment
-      # On x86-64 Linux, TLS variables are accessed via FS segment
-      # The offset is stored in sym.offset (allocated in pass2)
-      # Use RBP as base register (standard for offset-only addressing)
+      # A thread-local reached through a segment register: `SEG:[sym.offset]`,
+      # with the offset allocated in pass2. That is arkham's own FS block on the
+      # ELF target; on Windows the only such symbol is the fixed TEB field
+      # `arkham.teb.tlsptr.0` (`gs:0x58`), because a PE image's thread-locals
+      # live in a loader-allocated block reached THROUGH that field rather than
+      # at a fixed segment displacement — see `gsFixedSlot`.
+      # RBP as the base is what selects displacement-only addressing.
+      if ctx.arch == Arch.WinX64 and not sym.gsFixedSlot:
+        # A PE thread-local is NOT at a fixed segment displacement: the loader puts
+        # each thread's block wherever it likes and records the address in the TEB,
+        # so the producer has to walk there (arkham's `emTvarAddr`) and deref the
+        # pointer it gets. Encoding this as `fs:[off]` would read an unrelated
+        # address, silently — so it is refused instead of assembled.
+        error("thread-local '" & ctx.nameOf(sym.name) &
+              "' needs an address-then-deref on win_x64, not a segment operand", n)
       result.kind = okMem
       result.mem = x86.MemoryOperand(
         base: x86.RBP,  # RBP allows displacement-only addressing
         displacement: int32(sym.offset),
         hasIndex: false,
-        useFsSegment: true  # Use FS segment register
+        seg: (if sym.gsFixedSlot: x86.segGs else: x86.segFs)
       )
       result.typ = sym.typ
       inc n
@@ -880,13 +891,17 @@ proc parseDest*(n: var Cursor; ctx: var GenContext;
          error("Variable has no location", n)
        inc n
     elif sym != nil and sym.kind == skTvar:
-       # Writing to thread local variable via FS segment
+       # A thread-local written through a segment register — see the read side for
+       # what `gsFixedSlot` selects and why win_x64 refuses the plain form.
+       if ctx.arch == Arch.WinX64 and not sym.gsFixedSlot:
+         error("thread-local '" & ctx.nameOf(sym.name) &
+               "' needs an address-then-deref on win_x64, not a segment operand", n)
        result.kind = okMem
        result.mem = x86.MemoryOperand(
          base: RBP,  # RBP allows displacement-only addressing
          displacement: int32(sym.offset),
          hasIndex: false,
-         useFsSegment: true  # Use FS segment register
+         seg: (if sym.gsFixedSlot: x86.segGs else: x86.segFs)
        )
        result.typ = sym.typ
        inc n

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -360,6 +360,38 @@ proc arkhamWinStdcallTests() =
          " (want 3 = fn-pointer call | OS thread callback)"
   echo "1 / 1 arkham win64 stdcall-callback tests successful"
 
+proc arkhamWinTlsTests() =
+  ## `{.threadvar.}` on win_x64. It used to be collected as an ORDINARY GLOBAL —
+  ## written down as a deliberate choice, on the premise that "the PE image is
+  ## single-threaded (the native backend spawns no threads)". `std/rawthreads`
+  ## calls `CreateThread`, so what the demotion really did was give every thread
+  ## ONE shared copy of every thread-local, silently: `threadpool.threadIdx`, the
+  ## current exception, and `system/memory.allocator` — one unlocked heap region
+  ## for all threads.
+  ##
+  ## `tests/win_tls.c.nif` scores three things and exits with the sum:
+  ##   1,2 — each of two threads writes its own value, spins long enough that the
+  ##         other has certainly written too, and reads it back;
+  ##   4   — the MAIN thread's value still stands after both have run. This one is
+  ##         not a race: with one shared cell a worker's write always clobbers it.
+  ## Pre-fix this scored 2 (one thread happened to run last); it wants 7.
+  if findExe("wine").len == 0:
+    echo "0 / 0 arkham win64 thread-local tests (wine not installed)"
+    return
+  let arkham = ("bin" / "arkham").addFileExt(ExeExt)
+  let nifasm = ("bin" / "nifasm").addFileExt(ExeExt)
+  let workDir = "tests" / "arkham" / "nimcache"
+  let asmNif = workDir / "win_tls.asm.nif"
+  let exe = workDir / "win_tls.exe"
+  exec quoteShell(arkham) & " -a:win_x64 -o:" & quoteShell(asmNif) & " " &
+       quoteShell("tests" / "win_tls.c.nif")
+  exec quoteShell(nifasm) & " -o:" & quoteShell(exe) & " " & quoteShell(asmNif)
+  let (_, code) = execCmdEx("wine " & quoteShell(exe) & " 2>/dev/null")
+  if code != 7:
+    quit "FAILURE arkham win64 thread-locals: exit code " & $code &
+         " (want 7 = threadA | threadB | main survived)"
+  echo "1 / 1 arkham win64 thread-local tests successful"
+
 proc buildToolchain() =
   ## `bin/arkham` and `bin/nifasm`, built ONCE and BEFORE anything that runs them.
   ##
@@ -2345,6 +2377,7 @@ when defined(linux) and defined(amd64):
   arkhamWinUnwindTests()
   arkhamWinTraceTableTests()
   arkhamWinStdcallTests()
+  arkhamWinTlsTests()
 
 # Additionally exercise the AArch64 backend on an x86-64 Linux host by emitting the
 # `linux_arm64` ELF variant and running it under qemu-aarch64 (no-op if qemu is

--- a/tests/win_tls.c.nif
+++ b/tests/win_tls.c.nif
@@ -1,0 +1,155 @@
+(.nif27)
+(stmts
+ (type :Cb.0 .
+  (proctype .
+   (params
+    (param :p.0 .
+     (ptr
+      (void))))
+   (u 32)
+   (pragmas
+    (stdcall))))
+ (proc :CreateThread.0
+  (params
+   (param :attrs.0 .
+    (ptr
+     (void)))
+   (param :stack.0 .
+    (u 64))
+   (param :start.0 . Cb.0)
+   (param :arg.0 .
+    (ptr
+     (void)))
+   (param :flags.0 .
+    (u 32))
+   (param :tid.0 .
+    (ptr
+     (u 32))))
+  (ptr
+   (void))
+  (pragmas
+   (importc "CreateThread")
+   (dynlib "kernel32"))
+  (stmts .))
+ (proc :WaitForSingleObject.0
+  (params
+   (param :h.0 .
+    (ptr
+     (void)))
+   (param :ms.0 .
+    (u 32)))
+  (u 32)
+  (pragmas
+   (importc "WaitForSingleObject")
+   (dynlib "kernel32"))
+  (stmts .))
+ (proc :ExitProcess.0
+  (params
+   (param :code.0 .
+    (u 32))).
+  (pragmas
+   (importc "ExitProcess")
+   (dynlib "kernel32"))
+  (stmts .))
+ (tvar :tv.0 .
+  (i 64)0)
+ (gvar :spin.0 .
+  (i 64)0)
+ (gvar :cellA.0 .
+  (i 64)11)
+ (gvar :cellB.0 .
+  (i 64)22)
+ (proc :worker.0
+  (params
+   (param :p.0 .
+    (ptr
+     (void))))
+  (u 32)
+  (pragmas
+   (stdcall))
+  (stmts
+   (var :q.0 .
+    (ptr
+     (i 64))
+    (cast
+     (ptr
+      (i 64))p.0))
+   (asgn tv.0
+    (deref q.0))
+   (var :i.0 .
+    (i 64)0)
+   (while
+    (lt i.0 4000000)
+    (stmts
+     (asgn spin.0
+      (add
+       (i 64)spin.0 1))
+     (asgn i.0
+      (add
+       (i 64)i.0 1))))
+   (asgn
+    (deref q.0)tv.0)
+   (ret 0)))
+ (proc :main.0
+  (params)
+  (i 32)
+  (pragmas
+   (exportc "main"))
+  (stmts
+   (var :score.0 .
+    (i 64)0)
+   (asgn tv.0 99)
+   (var :tidA.0 .
+    (u 32)0)
+   (var :tidB.0 .
+    (u 32)0)
+   (var :hA.0 .
+    (ptr
+     (void))
+    (call CreateThread.0
+     (nil)0 worker.0
+     (cast
+      (ptr
+       (void))
+      (addr cellA.0))0
+     (addr tidA.0)))
+   (var :hB.0 .
+    (ptr
+     (void))
+    (call CreateThread.0
+     (nil)0 worker.0
+     (cast
+      (ptr
+       (void))
+      (addr cellB.0))0
+     (addr tidB.0)))
+   (var :wA.0 .
+    (u 32)
+    (call WaitForSingleObject.0 hA.0 20000))
+   (var :wB.0 .
+    (u 32)
+    (call WaitForSingleObject.0 hB.0 20000))
+   (if
+    (elif
+     (eq cellA.0 11)
+     (stmts
+      (asgn score.0
+       (add
+        (i 64)score.0 1)))))
+   (if
+    (elif
+     (eq cellB.0 22)
+     (stmts
+      (asgn score.0
+       (add
+        (i 64)score.0 2)))))
+   (if
+    (elif
+     (eq tv.0 99)
+     (stmts
+      (asgn score.0
+       (add
+        (i 64)score.0 4)))))
+   (call ExitProcess.0
+    (conv
+     (u 32)score.0)))))


### PR DESCRIPTION
`{.threadvar.}` was collected as an ORDINARY GLOBAL on Windows. That was a deliberate choice with a reason written next to it -- "the PE image is single-threaded (the native backend spawns no threads)" -- and the reason was false: `std/rawthreads` calls `CreateThread` and `std/threadpool` spawns one worker per core. So every thread shared ONE copy of every thread-local, silently. Not just `threadpool.threadIdx` and the current exception: `system/memory.allocator` is a threadvar too, so every multithreaded native Windows program was running all its threads through one unlocked heap region.

It surfaced as an intermittent seq bound check inside `std/ioring` under Wine, about one native run in eight. `ioLane()` is `threadIdx`, so the main thread and all 31 workers answered the same lane and drove one unlocked slot arena: double `complete()`, the same index on the freelist twice, and finally an index that walks off the end.

The fix is the mechanism the loader already provides. A `.tls` section carries one thread's block as a TEMPLATE and an `IMAGE_TLS_DIRECTORY64` describes it; the loader copies it for every thread the process creates -- `CreateThread`'d ones included -- and records the copy in
`TEB->ThreadLocalStoragePointer[*AddressOfIndex]`. Nothing runs per thread, so unlike the ELF target (`arch_prctl(ARCH_SET_FS)` in the entry stub, and the runtime for every thread it makes) there is no hook to forget.

`&threadvar` becomes, staged entirely through the destination register so it needs no scratch:

    gload D, arkham.tlsindex.0     ; our TLS index, filled by the loader
    shl   D, 3
    add   D, gs:0x58               ; += TEB->ThreadLocalStoragePointer
    mov   D, (D)                   ; this thread's block
    lea   D, D, <tvar>             ; + the tvar's offset

nifasm side: a `SegOverride` prefix (FS 0x64 / GS 0x65) where there was a `useFsSegment` bool; `Symbol.gsFixedSlot` for `arkham.teb.tlsptr.0`, which is not a variable but the fixed TEB field; `arkham.tlsindex.0` as an ordinary `.bss` cell the TLS directory names; `setupTlsWin` to build the template; and `.tls` placed BEFORE `.reloc` because its four absolute VAs need reloc entries. A bare `fs:[off]` tvar operand is now REFUSED on win_x64 rather than assembled against an address that means nothing there -- which is what caught the last missed site.

arkham side: stop demoting, in `collect` and in `lookupSym`'s foreign arm (both halves, or a foreign tvar reads back as a global); a Windows body for `emTvarAddr`; and `winTvarPtr`/`winTvarMov` so scalar and float accesses take the address-then-deref form, since a PE thread-local has no folded segment form the way `fs:[off]` is one.

Foreign tvar offsets are now pre-allocated on win_x64 too. Missing that gate was worth its own bug: every reference baked offset 0, so all thread-locals aliased each other at the block's base.

`tests/win_tls.c.nif` scores two threads keeping their own value across an overlapping spin, plus the main thread's surviving both. It scores 2 with the demotion restored and 7 without it.