### PR TITLE
arkham: &threadvar on win_x64 must give the register back as it found it

### DIFF
--- a/src/arkham/x64/mem.nim
+++ b/src/arkham/x64/mem.nim
@@ -237,9 +237,33 @@ proc emTvarAddr*(g: var CodeGen; dest: Reg; name: string) =
     # staging budget. (See `nifasm/driver.setupTlsWin` for the other half.)
     # `dest` carries a raw address while the block is being walked to: the two
     # loads and the shift are integer arithmetic, and a `dest` still bound as
-    # `(ptr T)` would make nifasm reject the `shl`. The caller rebinds it to the
-    # pointer type it wants once the address is formed (`winTvarPtr`); both
-    # rebinds are zero machine code.
+    # `(ptr T)` would make nifasm reject the `shl`. So the staging RETYPES it —
+    # and then puts back whatever binding it found, because that is the contract
+    # the ELF arm below keeps for free (two instructions, no retype), and the one
+    # every caller is written against: the register handed in is already typed for
+    # the value it will HOLD, by the allocator or by the caller's own `bindTemp`.
+    # `prematLval2` says so out loud ("already bound by the caller").
+    #
+    # Leaving the staging type on it instead named the register `(i 64)` while it
+    # carried a pointer, and nifasm — which type-checks operands, not registers —
+    # rejected the first use that cared. On a thread-local `seq` that use is the
+    # emptiness test after the words are loaded back through the address:
+    #     (rebind :`tmp88.0 (i 64) (r12))    ← should still be `(aptr string)`
+    #     … gload/shl/add/mov/lea → r12 = &tvar …
+    #     (mov `tmp88.0 (mem (dot (cast (ptr seq…) `tmp88.0) data.0)))
+    #     (cmp `tmp88.0 (nil))               ← "requires compatible types"
+    # which is the shape `std/cmdline.paramStr` has on Windows (`ownArgv
+    # {.threadvar.}: seq[string]`) — so every `nimony n -d:release` build that
+    # reached it died, `tests/boot` included.
+    #
+    # All three rebinds are naming directives: zero machine code.
+    let heldTemp = g.rb.isBoundTemp(dest)
+    let heldSlot = (if heldTemp and g.tmpBindTyp.hasKey(dest): g.tmpBindTyp[dest]
+                    else: AddrSlot)
+    var heldLocal: seq[tuple[r: Reg, name: string]] = @[]
+    if not heldTemp:
+      let nm = g.rb.boundName(dest)
+      if nm.len > 0 and g.nameBindTyp.hasKey(nm): heldLocal.add (r: dest, name: nm)
     g.releaseStaleName(dest)
     g.bindTemp(dest, AddrSlot)
     g.ab.tree GloadX64: (g.emReg dest; g.ab.sym TlsIndexName)      # dest ← our TLS index
@@ -247,6 +271,9 @@ proc emTvarAddr*(g: var CodeGen; dest: Reg; name: string) =
     g.ab.tree AddX64: (g.emReg dest; g.ab.sym TebTlsPtrName)       # dest += gs:[0x58]
     g.ab.tree MovX64: (g.emReg dest; g.ab.tree MemX: g.emReg dest) # dest ← this thread's block
     g.ab.tree LeaX64: (g.emReg dest; g.emReg dest; g.ab.sym name)  # dest += tvar offset
+    g.releaseStaleName(dest)                                       # drop the staging name
+    if heldLocal.len > 0: g.restoreBindings(heldLocal)             # the allocator's local
+    else: g.bindTemp(dest, heldSlot)                               # the caller's staging type
     return
   g.ab.tree MovX64: (g.emReg dest; g.ab.sym TlsSelfName)         # dest ← FS:[0], this thread's block
   g.ab.tree LeaX64: (g.emReg dest; g.emReg dest; g.ab.sym name)  # dest += tvar FS offset

--- a/src/arkham/x64/value.nim
+++ b/src/arkham/x64/value.nim
@@ -126,11 +126,12 @@ proc winTvarPtr(g: var CodeGen; loc: Location; what: string): Reg =
   if not cursorIsNil(loc.typ.typ):
     pSlot = typeToSlot(g.prog.ptrTypeOf(loc.typ.typ))
   result = g.pickStagingSealed(what, pSlot)
+  # `pSlot` is what the deref below wants, and it is what comes back out:
+  # `emTvarAddr` stages its block walk through this register under a raw-address
+  # type, then restores the binding it was handed. This used to re-establish
+  # `pSlot` itself, which read as "only this caller needs it" — the site that
+  # forgot to is what #157 shipped with.
   g.emTvarAddr(result, loc.name)
-  # `emTvarAddr` left it bound as a raw address (it does arithmetic on the way to
-  # the block); the deref below wants the thread-local's precise pointee type.
-  g.releaseStaleName(result)
-  g.bindTemp(result, pSlot)
 
 proc winTvarMov(g: var CodeGen; loc: Location; reg: Reg; load: bool) =
   ## A thread-local GPR scalar access on Windows: address, then deref.

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -392,6 +392,40 @@ proc arkhamWinTlsTests() =
          " (want 7 = threadA | threadB | main survived)"
   echo "1 / 1 arkham win64 thread-local tests successful"
 
+proc arkhamWinTvarFieldTests() =
+  ## Reading a FIELD of a thread-local aggregate on win_x64 — the half of `{.threadvar.}`
+  ## `win_tls` does not reach, and it scores 7 whether or not this works.
+  ##
+  ## Unlike the ELF arm, the PE block walk (`gload`/`shl`/`add`/`mov`/`lea`) is integer
+  ## arithmetic, so `emTvarAddr` has to retype the register it stages through. It used to
+  ## leave it retyped, and the register the caller handed in is usually one the allocator
+  ## already typed for the value it will HOLD. So the field load landed in a name still
+  ## declared `(i 64)`, and nifasm — which type-checks operands — refused the first use
+  ## that cared:
+  ##     (cmp `tmp3.0 (nil))   Operation 'cmp' requires compatible types, got (i 64) and nil
+  ## `tests/win_tvar_field.c.nif` is that shape at its smallest: a thread-local
+  ## `{data: ptr, len: int}`, its `data` read into a local, compared against `nil`, and
+  ## dereferenced. It exits 41 (the pointee) when the binding survives the walk, and does
+  ## not ASSEMBLE at all when it does not — which is how the real one presented, in
+  ## `std/cmdline.paramStr` (`ownArgv {.threadvar.}: seq[string]`), taking every
+  ## `nimony n -d:release` build on Windows down with it.
+  if findExe("wine").len == 0:
+    echo "0 / 0 arkham win64 thread-local field tests (wine not installed)"
+    return
+  let arkham = ("bin" / "arkham").addFileExt(ExeExt)
+  let nifasm = ("bin" / "nifasm").addFileExt(ExeExt)
+  let workDir = "tests" / "arkham" / "nimcache"
+  let asmNif = workDir / "win_tvar_field.asm.nif"
+  let exe = workDir / "win_tvar_field.exe"
+  exec quoteShell(arkham) & " -a:win_x64 -o:" & quoteShell(asmNif) & " " &
+       quoteShell("tests" / "win_tvar_field.c.nif")
+  exec quoteShell(nifasm) & " -o:" & quoteShell(exe) & " " & quoteShell(asmNif)
+  let (_, code) = execCmdEx("wine " & quoteShell(exe) & " 2>/dev/null")
+  if code != 41:
+    quit "FAILURE arkham win64 thread-local field: exit code " & $code &
+         " (want 41 = tv.data survived the block walk and derefed)"
+  echo "1 / 1 arkham win64 thread-local field tests successful"
+
 proc buildToolchain() =
   ## `bin/arkham` and `bin/nifasm`, built ONCE and BEFORE anything that runs them.
   ##
@@ -2378,6 +2412,7 @@ when defined(linux) and defined(amd64):
   arkhamWinTraceTableTests()
   arkhamWinStdcallTests()
   arkhamWinTlsTests()
+  arkhamWinTvarFieldTests()
 
 # Additionally exercise the AArch64 backend on an x86-64 Linux host by emitting the
 # `linux_arm64` ELF variant and running it under qemu-aarch64 (no-op if qemu is

--- a/tests/win_tvar_field.c.nif
+++ b/tests/win_tvar_field.c.nif
@@ -1,0 +1,48 @@
+(.nif27)
+(stmts
+ (type :Seqish.0 .
+  (object .
+   (fld :data.0 .
+    (ptr
+     (i 64)))
+   (fld :len.0 .
+    (i 64))))
+ (proc :ExitProcess.0
+  (params
+   (param :code.0 .
+    (u 32))).
+  (pragmas
+   (importc "ExitProcess")
+   (dynlib "kernel32"))
+  (stmts .))
+ (gvar :cell.0 .
+  (i 64)41)
+ (tvar :tv.0 . Seqish.0 .)
+ (proc :main.0
+  (params)
+  (i 32)
+  (pragmas
+   (exportc "main"))
+  (stmts
+   (asgn
+    (dot tv.0 data.0)
+    (addr cell.0))
+   (var :p.0 .
+    (ptr
+     (i 64))
+    (dot tv.0 data.0))
+   (var :s.0 .
+    (i 64)0)
+   (if
+    (elif
+     (eq p.0
+      (nil))
+     (stmts
+      (asgn s.0 1)))
+    (else
+     (stmts
+      (asgn s.0
+       (deref p.0)))))
+   (call ExitProcess.0
+    (conv
+     (u 32)s.0)))))


### PR DESCRIPTION
`emTvarAddr`'s Windows arm walks the TEB to find this thread's block, and stages the whole walk through `dest` so it needs no scratch register -- which is what lets it be called from inside an address computation that has already spent its staging budget. The walk is integer arithmetic (`gload`/`shl`/`add`/`mov`/`lea`), so it retypes `dest` to a raw-address slot on the way in. It then LEFT it retyped.

The ELF arm is two instructions and never touches the binding, so every caller is written against a register that keeps the type it arrived with -- typed by the allocator for the value it will HOLD, or by the caller's own `bindTemp`. `prematLval2` says so out loud: "already bound by the caller". Only `winTvarPtr` compensated, by re-establishing its own type afterwards; that read as "this caller needs it", not as "everyone does", and every other caller inherited an `(i 64)`-named register carrying a pointer.

nifasm type-checks operands, not registers, so nothing complained until the first use that cared. On a thread-local `seq` that is the emptiness test after the words are read back through the address:

    (rebind :`tmp88.0 (i 64) (r12))     <- should still be (aptr string)
    ... gload/shl/add/mov/lea -> r12 = &tvar ...
    (mov `tmp88.0 (mem (dot (cast (ptr seq...) `tmp88.0) data.0)))
    (cmp `tmp88.0 (nil))    Operation 'cmp' requires compatible types,
                            got (i 64) and nil

which is the shape `std/cmdline.paramStr` has on Windows (`ownArgv {.threadvar.}: seq[string]`) -- so every `nimony n -d:release` build that reached it failed to assemble, nimony's `tests/boot` included. It needs `-d:release`: without shoggoth the address and the value land in different registers and the stale name is never read.

The fix is one place, not seven: `emTvarAddr` saves whatever binding `dest` carries -- an allocator-assigned local through `restoreBindings`, a caller's `bindTemp` slot otherwise -- and puts it back once the address is formed. All the rebinds are naming directives, zero machine code. `winTvarPtr`'s manual compensation goes away with it.

`tests/win_tvar_field.c.nif` is the shape at its smallest: a thread-local `{data: ptr, len: int}` whose `data` is read into a local, compared against `nil` and dereferenced. It exits 41 when the binding survives the walk and does not ASSEMBLE when it does not. `win_tls` could not have caught this -- it scores 7 either way, because a scalar thread-local goes through `winTvarPtr`, the one site that already worked.