### PR TITLE
ithaqua: a C-linkage gvar pair must share one linear-memory slot

### DIFF
--- a/src/ithaqua/codegen_wasm.nim
+++ b/src/ithaqua/codegen_wasm.nim
@@ -93,7 +93,9 @@ type
     nextFunc: uint32                       ## next function index (imports pre-assigned)
     typeIdxOf: Table[string, uint32]       ## rendered signature key → functype index
     memTop: uint32                         ## static-data bump pointer
-    globalAddr: Table[string, uint32]
+    globalAddr: Table[string, uint32]  # canonical gvar ref name -> linear memory address
+    canonDecl: Table[string, Cursor]   # canonical ref name -> its decl, remembered
+                                       # before the name is canonicalized away
     rodataAddr: Table[string, uint32]      ## string literal → address (deduped)
     dataSegs: seq[(uint32, string)]
     allocLog: seq[(uint32, uint32, string)]    ## (addr, size, owner) for the
@@ -233,11 +235,28 @@ proc flexPayloadLen(g: var WasmGen; initv: Cursor): int =
           while kv.hasMore: skip kv
       skip t
 
+proc declHasInit(decl: Cursor): bool =
+  ## True when a `(gvar|tvar :name PRAGMAS TYPE INIT?)` carries an initializer.
+  var d = decl
+  result = false
+  d.into:
+    inc d                                      # name
+    skip d                                     # pragmas
+    skip d                                     # type
+    result = d.hasMore and d.kind != DotToken
+    while d.hasMore: skip d
+
 proc globalAddrOf(g: var WasmGen; name: string): uint32 =
   ## The linear-memory address of a gvar/const, assigning it on first use.
   ## Zero-initialized globals reserve address space only (wasm memory is
   ## zeroed); constant initializers become data segments at finalize.
-  if g.globalAddr.hasKey(name): return g.globalAddr[name]
+  ##
+  ## The slot is keyed by the canonical ref name: `gvarRefName` unifies the
+  ## exportc/importc pair of a C-linkage gvar (cmdCount, cmdLine, nimEnviron)
+  ## the way the C backend's one C symbol per pair does. Keying by the raw
+  ## NIF name gave `gExp.0` and the foreign `gImp.0` two slots, so a write
+  ## through one name was invisible to a read through the other.
+  let canon = gvarRefName(g.prog, name)
   let si = lookupSym(typeCtx(g), name)
   if si.cat notin {scGlobal, scTvar}:          # tvar: single-threaded target → a global
     err g, "not a global: " & name
@@ -254,11 +273,19 @@ proc globalAddrOf(g: var WasmGen; name: string): uint32 =
       initv = d
       hasInit = true
     while d.hasMore: skip d
+  if g.globalAddr.hasKey(canon):
+    # the slot exists; but the pair's other decl may carry the static
+    # initializer this one lacks, and emitGlobalInit reads the decl from
+    # canonDecl, so upgrade it
+    if hasInit and not declHasInit(g.canonDecl[canon]):
+      g.canonDecl[canon] = si.decl
+    return g.globalAddr[canon]
   var (sz, al) = typeSizeAlign(g.prog, typ)
   if hasInit:
     sz += flexPayloadLen(g, initv)             # flexarray tail data (string consts)
-  result = allocStatic(g, sz, al, tag = name)
-  g.globalAddr[name] = result
+  result = allocStatic(g, sz, al, tag = canon)
+  g.globalAddr[canon] = result
+  g.canonDecl[canon] = si.decl                 # the drain loop cannot re-derive this
   if si.cat == scGlobal and not g.globals.hasKey(name):
     g.globals[name] = si.decl                  # cache foreign decls for typenav
   elif si.cat == scTvar and not g.tvars.hasKey(name):
@@ -2896,9 +2923,11 @@ proc emitGlobalInit(g: var WasmGen; nm: string; addrv: uint32) =
   ## reserve address space only; runtime inits are the ini chain's job. A
   ## Symbol initializer naming a proc is a static fn-ptr default → its
   ## funcref-table slot (this can discover new reachable procs).
-  let si = lookupSym(typeCtx(g), nm)
-  if si.cat notin {scGlobal, scTvar}: return
-  var d = si.decl
+  # `nm` is the canonical ref name globalAddrOf keyed the slot under, which
+  # lookupSym cannot resolve for a C-linkage pair (`cmdCount.0`); the decl
+  # was remembered there for exactly this reason.
+  if not g.canonDecl.hasKey(nm): return
+  var d = g.canonDecl[nm]
   var typ, initv: Cursor
   var hasInit = false
   d.into:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -501,16 +501,17 @@ proc ithaquaTests() =
   ## ithaqua — the wasm32 back end — over the same hand-written Leng corpus
   ## arkham runs, plus `wasmenc`'s own encoder tests.
   ##
-  ## EMIT ONLY: each fixture must produce a file that starts with the wasm
-  ## magic, and the `ithaquaUnsupported` ones must be refused. Nothing here
-  ## RUNS a module. That is deliberate — the differential harness that executes
+  ## EMIT ONLY — bar one run check at the end, see its comment: each fixture
+  ## must produce a file that starts with the wasm magic, and the
+  ## `ithaquaUnsupported` ones must be refused. Nothing else here RUNS a
+  ## module. That is deliberate — the differential harness that executes
   ## wasm against the native backend as its oracle lives in nimony
   ## (`hastur wasmdiff`, see doc/ithaqua.md), where the front end that produces
   ## realistic input also lives. What this pass buys is the thing nimony's
   ## harness cannot see: that ithaqua still COMPILES against, and agrees with,
   ## the `core/` program model in this repo, over 200-odd fixtures, on every
   ## platform in the matrix.
-  discard requiredExe("node", "the wasmenc engine (validate + instantiate) checks")
+  let node = requiredExe("node", "the wasmenc engine checks and the ithaqua run check")
   # `showProgress`, so `twasmenc`'s own summary line — which says whether the
   # two engine-judged blocks ran or were skipped for want of node — reaches the
   # log. Swallowed, the skip it exists to announce would be invisible.
@@ -548,6 +549,47 @@ proc ithaquaTests() =
     inc passed
   echo passed, " / ", total - refused, " ithaqua wasm32 emit tests successful (",
        refused, " refused as expected)"
+
+  # One RUN-based exception to the emit-only rule, and here is its history:
+  # a C-linkage gvar pair (the `exportc` `gExp` definition, another module's
+  # `importc` `gImp`) must share ONE linear-memory slot. When it got two, the
+  # bug emitted a perfectly valid module — address identity is exactly what an
+  # emit check cannot see — and no nimony `hastur wasmdiff` fixture touched
+  # `cmdCount`, so the divergence from the native oracle (exit 0, not 42) was
+  # found by hand. Fixtures whose failure mode is address identity rather than
+  # encoding cannot be guarded by emit; run those, and extend this list when
+  # the next one is found.
+  const runChecked = @["gvar_clinkage"]
+  if node.len > 0:
+    let runner = workDir / "run_wasm.js"
+    writeFile runner, """const fs = require("fs");
+const b = fs.readFileSync(process.argv[2]);
+let inst;
+const imports = { env: {
+  nim_write: (fd, buf, len) => { const m = Buffer.from(inst.exports.memory.buffer, buf, len); process.stdout.write(m); return len; },
+  nim_exit: (code) => { process.exit(code); }
+}};
+inst = new WebAssembly.Instance(new WebAssembly.Module(b), imports);
+inst.exports._start();
+"""
+    for stem in runChecked:
+      let wasm = workDir / (stem & ".wasm")
+      let (o, code) = execCmdEx(quoteShell(ithaqua) & " -o:" & quoteShell(wasm) &
+                                " " & quoteShell("tests" / "arkham" / (stem & ".c.nif")))
+      if code != 0:
+        quit "FAILURE ithaqua run check (codegen) " & stem & "\n" & o
+      let expected = parseInt(readFile("tests" / "arkham" / (stem & ".exitcode")).strip)
+      let (outp, pc) = execCmdEx(quoteShell(node) & " " & quoteShell(runner) & " " &
+                                 quoteShell(wasm))
+      if pc != expected:
+        quit "FAILURE ithaqua run check: " & stem & " exits " & $pc &
+             " but the native oracle exits " & $expected & "\n" & outp
+      removeFile wasm
+    echo "ithaqua run check: ", runChecked.len,
+         " fixture(s) executed under node agree with the native oracle"
+  else:
+    echo "ithaqua run check: SKIPPED (no node) — ", runChecked.len,
+         " fixture(s) not executed; this run is thinner than it looks"
 
 proc arkhamTests() =
   ## Each `tests/arkham/*.c.nif` is hand-written Leng: arkham generates asm-NIF,


### PR DESCRIPTION
`globalAddrOf` keyed slots by the raw NIF name, so the `exportc "cmdCount"`
definition and another module's `importc "cmdCount"` reference got **two**
linear-memory slots: the ini chain wrote one, reads through the other saw
zero. `gvar_clinkage` exits 0 instead of the native oracle's 42.

The slot is now keyed by `gvarRefName` — arkham's own rule mapping a
C-linkage pair (cmdCount, cmdLine, nimEnviron) to one ref name, the same
rule that gives the C backend one C symbol per pair. Since the canonical
name can't be re-resolved through `lookupSym` at finalize time,
`globalAddrOf` remembers the decl and `emitGlobalInit` reads it from
there; the cache is upgraded when the pair's other decl carries the static
initializer, so a static init is never dropped by name order.

## tester: run gvar_clinkage under node

Nothing executed this fixture anywhere — the ithaqua pass is emit-only and
no nimony `wasmdiff` fixture touches `cmdCount` — so the bug kept CI green
while the module's exit code lied. One run-based check joins the suite:
fixtures whose failure mode is *address identity* rather than encoding get
executed under node and compared with their `.exitcode` oracle.
`gvar_clinkage` is the first entry; no node, the skip is announced.

## Verification

- `gvar_clinkage` exits 42 under node, matching the native oracle
- emit pass: 227/227, 25 refusals unchanged; `twasmenc` passes
- negative test: on the pre-fix codegen the emit pass still reports
  227/227 while the run check fails with "exits 0 but the native oracle
  exits 42"