### PR TITLE
arkham: the role goes in the identifier, the disambiguator stays a number

### DIFF
--- a/src/arkham/core/programs.nim
+++ b/src/arkham/core/programs.nim
@@ -564,6 +564,38 @@ proc isDeclarativeAbi*(p: var Program; decl: Cursor): bool =
     while c.hasMore: skip c                   # return type, pragmas, body
   result = true
 
+proc syprocAsmName*(cname, module: string): string =
+  ## The asm symbol for the syscall syproc wrapping the C function `cname`:
+  ## `` write`sys.0.<module> ``. It must be a proper SELF-MODULE symbol, since
+  ## nifasm resolves cross-module symbols by full module-qualified name (the
+  ## render compresses the suffix to a trailing dot and nifasm completes it
+  ## back) — a basename-only `write.sys` would be unresolvable from another
+  ## bundled module that calls it.
+  ##
+  ## The ROLE goes into the IDENTIFIER, where NIF puts a tag, and the
+  ## disambiguator stays the number the spec says it is (nimony/#2457): a
+  ## `.sys.` segment sat in the disambiguator's place and nothing but the
+  ## convention "nimony's are numeric" kept it apart. The backtick keeps the
+  ## result unspellable, so it still cannot collide with syncio's own
+  ## `write.0.<module>`, and keying on the C name still collapses aliases —
+  ## both `die` and `exit` (`importc "exit"`) give one syproc.
+  result = derivedName(cname & ".0", "sys") & "." & module
+
+proc extprocAsmName*(cname, module: string): string =
+  ## The asm symbol for the extern declaration of the C function `cname`:
+  ## `` write`c.0.<module> ``, mirroring `syprocAsmName` for the same reasons.
+  result = derivedName(cname & ".0", "c") & "." & module
+
+proc cNameOfAsmName*(asmName: string): string =
+  ## The C name back out of either of the two above: everything before the
+  ## backtick that introduces the role tag. Returns `asmName` unchanged when
+  ## there is none.
+  result = asmName
+  for i in 0 ..< asmName.len:
+    if asmName[i] == '`':
+      result = substr(asmName, 0, i-1)
+      break
+
 proc thisModuleSuffix*(p: Program): string =
   ## The main module's NIF symbol suffix (e.g. `sysvq0asl`), used to compress
   ## self-module symbol suffixes when serializing the embedded-index output.
@@ -764,16 +796,10 @@ proc collect*(buf: var TokenBuf; inputPath: string; tags: TagPool;
           # and declares the kernel's clobbers; calls go through the declarative
           # `(prepare …)` path with a `(syscall)`/`(svc)` marker. See genCall.
           let (_, x64Nr, a64Nr) = lookupSyscall(importcN)
-          # Name the syproc as a proper SELF-MODULE symbol `<name>.sys.<thisModule>`:
-          # nifasm resolves cross-module symbols by full module-qualified name (the render
-          # compresses the suffix to a trailing dot and nifasm completes it back), so a
-          # basename-only `mmap.sys` would be unresolvable from another bundled module that
-          # calls it. Keying on the C `importcN` (not the proc's own `pname`) also collapses
-          # aliases — e.g. both `die` and `exit` (`importc "exit"`) → one syproc. The `.sys.`
-          # disambiguator is RESERVED: nimony proc disambiguators are always numeric, so a
-          # synthesized syproc can never collide with a real proc of the same base name
-          # (e.g. the `write` syscall syproc vs syncio's own `write.0` proc).
-          let asmN = importcN & ".sys." & thisModuleSuffix(result)
+          # Keying on the C `importcN` (not the proc's own `pname`) collapses aliases —
+          # e.g. both `die` and `exit` (`importc "exit"`) → one syproc. See
+          # `syprocAsmName` for the shape and why it is that shape.
+          let asmN = syprocAsmName(importcN, thisModuleSuffix(result))
           result.callTarget[pname] = CallTarget(asmName: asmN, extern: false,
                                                 syscall: true, sysNr: x64Nr, sysNrA64: a64Nr,
                                                 declarative: true, retType: retType, sigType: sigType)
@@ -785,12 +811,10 @@ proc collect*(buf: var TokenBuf; inputPath: string; tags: TagPool;
             result.syscalls.add SyscallProc(asmName: asmN, decl: procStart,
                                             sysNr: x64Nr, sysNrA64: a64Nr)
         elif importcN.len > 0:
-          # Name the extproc as a proper SELF-MODULE symbol `<name>.c.<thisModule>`
-          # (mirroring the `.sys.` syprocs above): a basename-only `write.0` has one
-          # dot, so the render would treat it as module-LOCAL and leave it out of the
-          # `.index` — unresolvable when this module is a foreign module of a bundle.
-          # The `.c.` disambiguator is reserved (nimony proc disambiguators are numeric).
-          let asmN = importcN & ".c." & thisModuleSuffix(result)
+          # A basename-only `write.0` has one dot, so the render would treat it as
+          # module-LOCAL and leave it out of the `.index` — unresolvable when this
+          # module is a foreign module of a bundle. See `extprocAsmName`.
+          let asmN = extprocAsmName(importcN, thisModuleSuffix(result))
           if windows and dllN.len == 0:
             # No implicit import library: a Windows extern must NAME its dll
             # (a `dynlib: "kernel32"` on the Nim decl → `(dynlib …)` in Leng).
@@ -964,16 +988,16 @@ proc foreignCallTarget*(p: var Program; name: string): CallTarget =
     result = CallTarget(bitBuiltin: importcN, retType: retType, sigType: sigType)
   elif not p.darwin and not p.windows and importcN.len > 0 and lookupSyscall(importcN).found:
     let (_, x64Nr, a64Nr) = lookupSyscall(importcN)
-    result = CallTarget(asmName: importcN & ".sys." & s.module, extern: false,
+    result = CallTarget(asmName: syprocAsmName(importcN, s.module), extern: false,
                         syscall: true, sysNr: x64Nr, sysNrA64: a64Nr,
                         declarative: true, retType: retType, sigType: sigType)
   elif importcN.len > 0:
     # A genuine libc extern (the foreign module records it in its own externOrder
     # + needsLibSystem; here we only need the matching call target). The asm name
-    # is the module-qualified `<importc>.c.<that module>` the foreign module's
-    # extern decl uses (see the externOrder naming in `collect`).
+    # is the module-qualified name the foreign module's extern decl uses (see
+    # the externOrder naming in `collect`).
     p.needsLibSystem = true
-    result = CallTarget(asmName: importcN & ".c." & s.module, extern: true, retFloat: retFloat,
+    result = CallTarget(asmName: extprocAsmName(importcN, s.module), extern: true, retFloat: retFloat,
                         declarative: p.windows and isDeclarativeAbi(p, declCur),
                         retType: retType, sigType: sigType)
   else:

--- a/src/arkham/core/programs.nim
+++ b/src/arkham/core/programs.nim
@@ -894,7 +894,7 @@ proc lookupType*(p: var Program; id: SymId): Cursor =
   ## keyed by text). Foreign decls are interned into `p.pool` (see `getDecl`), so an
   ## id from a foreign type's body is comparable with a main-module one.
   if p.typeDecls.hasKey(id): return p.typeDecls[id]
-  let name = p.pool.syms[id]
+  let name = symString(p.pool, id)
   let s = splitSymName(name)
   if s.module.len == 0:
     raiseAssert "arkham: unknown type " & name
@@ -904,7 +904,7 @@ proc lookupType*(p: var Program; id: SymId): Cursor =
   # module — generic-instance names like `t.0.I….<self>.<self>` are the case.
   if s.module == p.scheme.name:
     let localName = name[0 ..< name.len - s.module.len]
-    let localId = p.pool.syms.getOrIncl(localName)
+    let localId = symId(p.pool, localName)
     if p.typeDecls.hasKey(localId): return p.typeDecls[localId]
     raiseAssert "arkham: unknown local type " & name
   let m = loadModule(p, s.module)
@@ -1536,7 +1536,7 @@ proc aggrLayout*(p: var Program; typeSym: SymId): seq[FieldInfo] =
     # underlying type is named by a `Symbol` token, which already carries its id.
     return aggrLayout(p, body.symId)
   assert body.kind == TagLit and body.typeKind == ObjectT,
-    "arkham: aggregate ABI requires an object type: " & p.pool.syms[typeSym]
+    "arkham: aggregate ABI requires an object type: " & symString(p.pool, typeSym)
   layoutObjBody(p, body, 0, result)
 
 proc canHomeInRegPair*(p: var Program; typeSym: SymId): bool =

--- a/src/arkham/core/typeutil.nim
+++ b/src/arkham/core/typeutil.nim
@@ -164,9 +164,10 @@ proc emTypeSym*(g: var CodeGen; id: SymId) {.inline.} =
   ##
   ## Everything upstream of this call is keyed by the id: `lookupType` and the
   ## layout API over it, `varType`, `Location.StackPtr.pointeeType` /
-  ## `Location.Field.aggrType`, `retAggrSym`. `pool.syms[]` yields `lent string`, so
-  ## the operand costs no copy.
-  g.ab.sym g.prog.pool.syms[id]
+  ## `Location.Field.aggrType`, `retAggrSym`. `symString` builds the spelling
+  ## from the pool's taken-apart form (nimony#2457), so this is the one place
+  ## that pays for it.
+  g.ab.sym symString(g.prog.pool, id)
 
 proc truncateImm*(v: int64; bits: int; signed: bool): int64 {.inline.} =
   ## Keep the low `bits` of `v`, sign-extending when `signed`. A Leng

--- a/src/arkham/risc/runtime.nim
+++ b/src/arkham/risc/runtime.nim
@@ -241,10 +241,10 @@ proc semiTtyName*(g: CodeGen): string {.inline.} =
   ## where it lives in a real program, because `system` is what imports `write`.
   ## The importer loads the shim, the shim names these two, and nifasm has
   ## nothing to resolve them against: "Unknown symbol: `shwh.0 in proc
-  ## write.sys.sysvq0asl".
+  ## write`sys.0.sysvq0asl".
   ##
   ## So they carry the module suffix, exactly as the syprocs beside them do
-  ## (`<name>.sys.<thisModule>`, see `programs.collect`) and for exactly the same
+  ## (`` <name>`sys.0.<thisModule> ``, see `programs.syprocAsmName`) and for the same
   ## reason. The render compresses the suffix back to a trailing dot for a
   ## same-module reference, so the emitted text is unchanged where it already
   ## worked.
@@ -311,14 +311,8 @@ proc emitSemihostRuntime*(g: var CodeGen; sp: SyscallProc) =
   ## rather than allocator output, so its raw r0–r3 uses are correct by
   ## construction and must not trip `emReg`'s unbound-scratch assertion (which
   ## exists to catch a temp that escaped the binder).
-  # `asmName` is `<cname>.sys.<module>` (see programs.collect); take the C name.
-  var base = sp.asmName
-  block:
-    for i in 0 ..< base.len - 4:
-      if base[i] == '.' and base[i+1] == 's' and base[i+2] == 'y' and
-         base[i+3] == 's' and base[i+4] == '.':
-        base = base.substr(0, i - 1)
-        break
+  # `asmName` is `` <cname>`sys.0.<module> `` (see programs.syprocAsmName).
+  let base = cNameOfAsmName(sp.asmName)
   case base
   of "exit":
     g.emitSemihostExitProc(sp.asmName)

--- a/src/ghast/translate.nim
+++ b/src/ghast/translate.nim
@@ -84,16 +84,16 @@ proc base(id: string): string =
 
 proc mint(pg: var ProcGen; name: string): SymId =
   ## Intern an id name into the shared pool, yielding its `SymId`.
-  pg.pool.syms.getOrIncl(name)
+  symId(pg.pool, name)
 
 proc stem(pg: ProcGen; id: SymId): string =
   ## The readable stem of an already-minted id — its pooled name minus the NIF
   ## module suffix (`int64.0` -> `int64`), used to name ids derived from it.
-  base(poolSym(pg.pool, id))
+  base(symString(pg.pool, id))
 
 proc freshId(m: var Module; prefix: string): SymId =
   inc m.counter
-  result = m.pool.syms.getOrIncl(prefix & $m.counter & idSuffix)
+  result = symId(m.pool, prefix & $m.counter & idSuffix)
 
 # ── types & constants (emitted into the per-proc `types` buffer) ────────────
 

--- a/src/ithaqua/codegen_wasm.nim
+++ b/src/ithaqua/codegen_wasm.nim
@@ -1385,10 +1385,10 @@ proc genInlineCall(g: var WasmGen; c: Cursor; wantValue: bool) =
     elif ct.syscall:
       # The WW3 runtime floor: write goes to the host, exit traps the
       # instance. Everything else traps loudly.
+      # the syscall's C name is encoded in the target's asmName
+      # `` <c>`sys.0.<mod> `` (see programs.syprocAsmName)
       var base = nm
-      # the syscall's C name is encoded in the target's asmName "<c>.sys.<mod>"
-      let dotSys = ct.asmName.find(".sys.")
-      if dotSys >= 0: base = ct.asmName[0 ..< dotSys]
+      if ct.asmName.len > 0: base = cNameOfAsmName(ct.asmName)
       case base
       of "write":
         let fdT = lengType(g, t)

--- a/src/nifasm/core/context.nim
+++ b/src/nifasm/core/context.nim
@@ -439,12 +439,12 @@ proc inCall*(ctx: GenContext): bool {.inline.} =
 template nameOf*(ctx: GenContext; s: SymId): string =
   ## Render a `SymId` back to its qualified name string (for the foreign-index
   ## lookup, dedup keys, diagnostics and extern emission — the genuine string sinks).
-  poolSym(ctx.pool, s)
+  symString(ctx.pool, s)
 
 template symIdOf*(ctx: GenContext; s: string): SymId =
   ## Intern a qualified name into the main pool, yielding its scope key. Cheap for a
   ## name already interned (parsing interned every symbol) — a single hash + probe.
-  ctx.pool.syms.getOrIncl(s)
+  symId(ctx.pool, s)
 
 proc newGenContext*(mainPool: Pool; baseDir, thisModule: string;
                     symMap, emitObj, debugInfo: bool; listing: string): GenContext =

--- a/src/nifasm/core/sem.nim
+++ b/src/nifasm/core/sem.nim
@@ -115,7 +115,7 @@ type
 
   Symbol* = ref object
     name*: SymId      # interned identity in the main-module pool; render with
-                      # `poolSym(pool, sym.name)` where a string is genuinely needed
+                      # `symString(pool, sym.name)` where a string is genuinely needed
                       # (foreign index lookup, dedup, diagnostics, extern emission).
     kind*: SymKind
     typ*: Type        # For procs, this is ProcT; for vars/params, the data type (StackOffT if on stack)

--- a/src/nifasm/image/writemacho.nim
+++ b/src/nifasm/image/writemacho.nim
@@ -176,18 +176,18 @@ proc writeMachOObject*(a: var GenContext; outfile: string) =
     case sym.kind
     of skProc:
       if labelPos.hasKey(sym.offset):
-        addDef(machoName(poolSym(mpool, sym.name)), macho.moText, uint64(labelPos[sym.offset]))
+        addDef(machoName(symString(mpool, sym.name)), macho.moText, uint64(labelPos[sym.offset]))
       else: -1
     of skRodata:
       if sym.dataConst:
-        (if sym.size < dataRegionSize: addDef(machoName(poolSym(mpool, sym.name)), macho.moData, uint64(sym.size)) else: -1)
+        (if sym.size < dataRegionSize: addDef(machoName(symString(mpool, sym.name)), macho.moData, uint64(sym.size)) else: -1)
       elif labelPos.hasKey(sym.offset):
-        addDef(machoName(poolSym(mpool, sym.name)), macho.moText, uint64(labelPos[sym.offset]))
+        addDef(machoName(symString(mpool, sym.name)), macho.moText, uint64(labelPos[sym.offset]))
       else: -1
     of skGvar:
       # A data symbol must point inside the emitted `__data` region; a zero-size
       # region (`bssOffset == 0`) emits no `__data` section, so skip it then.
-      if sym.size < dataRegionSize: addDef(machoName(poolSym(mpool, sym.name)), macho.moData, uint64(sym.size))
+      if sym.size < dataRegionSize: addDef(machoName(symString(mpool, sym.name)), macho.moData, uint64(sym.size))
       else: -1
     else: -1
 


### PR DESCRIPTION
A NIF symbol is `<name>.<disamb>[.<key>].<module>` with `disamb` a NUMBER (nimony#2457). The syproc and extproc names put a word there instead -- `_exit.sys.sysvq0asl`, `write.c.sysvq0asl` -- and nothing but the convention "nimony's disambiguators are numeric" kept the two apart.

They now read `` _exit`sys.0.sysvq0asl `` / `` write`c.0.sysvq0asl ``: the ROLE moves into the identifier, where NIF puts a tag and where `symparser.derivedName` already puts one, and the disambiguator is the number the spec says it is. The backtick keeps the name unspellable, so it still cannot collide with syncio's own `write.0.<module>`, and keying on the C name still collapses aliases (`die` and `exit`, both `importc "exit"`, give one syproc).

`syprocAsmName` / `extprocAsmName` / `cNameOfAsmName` put the shape and its inverse in one place; the two consumers that were hunting for the `.sys.` substring by hand (the RISC runtime shims, the wasm syscall floor) now ask for the C name instead.

Whole corpus green: 235 arkham, 230 x64 stress, 232 arm64 (qemu), 231 arm64 stress, plus the rejection/debug-info/win64 sets. Nothing tracked carried the old spelling -- the 736 files that do are generated.
